### PR TITLE
Auto color fix

### DIFF
--- a/enlighten/Multispec.py
+++ b/enlighten/Multispec.py
@@ -557,7 +557,6 @@ class Multispec(object):
             color = self.choose_color(spec)
         else:
             color = spec.assigned_color
-        log.debug(f"make pen called for spec {spec} with is auto of {self.is_autocolor()} color is {color}")
 
         try:
             pen = self.gui.make_pen(

--- a/enlighten/Multispec.py
+++ b/enlighten/Multispec.py
@@ -250,6 +250,7 @@ class Multispec(object):
             for spec in self.get_spectrometers():
                 if spec.app_state.hidden or spec.curve is None:
                     self.unhide(spec)
+                    spec.curve.setPen(self.make_pen(spec))
                 else:
                     spec.curve.setPen(self.make_pen(spec))
 
@@ -532,7 +533,7 @@ class Multispec(object):
     # ##########################################################################
 
     def check_callback(self):
-        self.seen_model_colors = set()
+        self.seen_model_colors = {}
         self.update_spectrometer_colors()
 
     def update_spectrometer_colors(self):
@@ -556,6 +557,7 @@ class Multispec(object):
             color = self.choose_color(spec)
         else:
             color = spec.assigned_color
+        log.debug(f"make pen called for spec {spec} with is auto of {self.is_autocolor()} color is {color}")
 
         try:
             pen = self.gui.make_pen(
@@ -570,8 +572,7 @@ class Multispec(object):
     def choose_color(self, spec):
         if self.is_autocolor() and spec.wp_model_info is not None:
             model_color = spec.wp_model_info.color
-            if model_color in self.seen_model_colors:
-
+            if model_color in self.seen_model_colors.keys() and self.seen_model_colors.get(model_color, None) != spec:
                 if spec.assigned_color is not None:
                     color = spec.assigned_color
                 else:
@@ -580,7 +581,7 @@ class Multispec(object):
                         color = self.colors.get_next_random()
             else:
                 color = model_color
-                self.seen_model_colors.add(color)
+                self.seen_model_colors[color] = spec
         else:
             color = self.colors.get_by_widget("scope")
             if color in self.seen_colors:


### PR DESCRIPTION
Issue was that when hiding color was still in seen model colors without telling which spec it was associated with. So when unhiding it was like connecting a new spec while thinking the model color was taken. Changed model colors from set to dict so model color can be associated with a spec and fixed the if check.