### PR TITLE
Mzieg raman shift correction

### DIFF
--- a/README_CHANGELOG.md
+++ b/README_CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # 3.2 Open-Source
 
+- 2022-10-10 3.2.34
+    - fix Raman Shift Correction
 - 2022-09-28 3.2.33
     - change tensorflow to hidden import to speed up start
 - 2022-10-03 3.2.32

--- a/enlighten/RamanShiftCorrectionFeature.py
+++ b/enlighten/RamanShiftCorrectionFeature.py
@@ -269,10 +269,10 @@ class RamanShiftCorrectionFeature(object):
     # In this case, we get called after each new processed_reading so we can 
     # re-scale the peaks against the current maxima.
     def update_graph(self):
-        log.debug("updating graph")
+        # log.debug("updating graph")
 
         if not self.curve_visible:
-            log.debug("not visible")
+            # log.debug("not visible")
             return
 
         if self.compound_name is None:
@@ -304,7 +304,7 @@ class RamanShiftCorrectionFeature(object):
             
         max_intensity = max(pr.processed)
         min_intensity = min(pr.processed)
-        log.debug("min = %d, max = %d", min_intensity, max_intensity)
+        # log.debug("min = %d, max = %d", min_intensity, max_intensity)
 
         if len(compound.peaks) == 0:
             self.curve.setData([])
@@ -339,10 +339,10 @@ class RamanShiftCorrectionFeature(object):
 
             peak_cm = peak.wavenumber
             if peak_cm < x_min_cm:
-                log.debug("can't see %s peak at %.2f (too low)", self.compound_name, peak_cm)
+                # log.debug("can't see %s peak at %.2f (too low)", self.compound_name, peak_cm)
                 continue
             elif peak_cm > x_max_cm:
-                log.debug("can't see %s peak at %.2f (too high)", self.compound_name, peak_cm)
+                # log.debug("can't see %s peak at %.2f (too high)", self.compound_name, peak_cm)
                 continue
 
             intensity = peak.intensity

--- a/enlighten/RamanShiftCorrectionFeature.py
+++ b/enlighten/RamanShiftCorrectionFeature.py
@@ -502,7 +502,7 @@ class RamanShiftCorrectionFeature(object):
             shift_cm = peak.wavenumber - measured_cm
 
             # was this match "good enough"?
-            if shift_cm > self.MAX_WAVENUMBER_SHIFT:
+            if abs(shift_cm) > self.MAX_WAVENUMBER_SHIFT:
 
                 # it's okay to fail to match any one ASTM peak...
                 log.debug("failed to match ASTM peak %.2f to any declared peak in the measurement")

--- a/enlighten/common.py
+++ b/enlighten/common.py
@@ -13,7 +13,7 @@ application.
       can be modules (files) within it
 """
 
-VERSION = "3.2.33"
+VERSION = "3.2.34"
 
 """ ENLIGHTEN's application version number (checked by scripts/deploy and bootstrap.bat) """
 


### PR DESCRIPTION
Fixed two bugs:

- Original code checked if delta was 'less than' MAX_WAVENUMBER_SHIFT, which didn't cover the case of the delta being strongly negative; correct comparison uses abs(delta)
- Original code (in Wasatch.PY) had a bug where we might use a floating-point pixel coordinate as a list index lookup (the value was actually integral, but the datatype was float64)