### PR TITLE
Trying to get pytest working

### DIFF
--- a/README_TESTING.md
+++ b/README_TESTING.md
@@ -1,10 +1,20 @@
 # Regression Testing
 
-This module uses pytest in order to run tests.
+This module uses pytest in order to run tests.  Mocks are provided by wasatch.MockUSBDevice.
 
-To run the tests in the /test folder from the CLI call:
+## Running Tests
+
+To run all tests in the /test folder from the CLI call:
 
 	pytest .\test
+
+To run only the release tests:
+
+    pytest .\test -m release
+
+To run a single test:
+
+    pytest -v .\test\test_usb.py::TestUSB::test_set_int_time_enlighten
 
 ## Writing a Test
 
@@ -12,12 +22,6 @@ The short summary is classes start with Test, functions start with test_. Pytest
 
 - https://docs.pytest.org/en/6.2.x/getting-started.html#create-your-first-test
 - https://docs.pytest.org/en/6.2.x/example/markers.html#mark-examples
-
-To run only the release tests use ```pytest .\test -m release```
-
-## User Testing
-
-- 1920x1080 resolution (production)
 
 ## Initial Test Plan
 
@@ -36,4 +40,4 @@ To run only the release tests use ```pytest .\test -m release```
 - Absorbance Technique
     - reference works
 
-All of the above with no Traceback reported in log.
+All of the above with no Traceback or CRITICAL reported in log.

--- a/enlighten/Controller.py
+++ b/enlighten/Controller.py
@@ -277,7 +277,7 @@ class Controller:
             # hiding tends to mess with gui tests since the componets are also hidden
             # So I replaced with minimizing, which I recognize is not a true headless
             # self.hide()
-            self.showMinimized()
+            self.form.showMinimized()
 
 
     def disconnect_device(self, spec=None, closing=False):

--- a/enlighten/Multispec.py
+++ b/enlighten/Multispec.py
@@ -405,6 +405,11 @@ class Multispec(object):
         return False
 
     def get_spectrometer(self, device_id) -> Spectrometer:
+        log.debug(f"get_spectrometer: asked to get device_id {device_id}")
+        log.debug(f"get_spectrometer: currently have these spectrometer keys:")
+        for k in sorted(self.spectrometers, key=str):
+            log.debug(f"  {k}")
+
         return self.spectrometers.get(device_id,None)
 
     def is_autocolor(self) -> bool:

--- a/enlighten/Multispec.py
+++ b/enlighten/Multispec.py
@@ -405,11 +405,6 @@ class Multispec(object):
         return False
 
     def get_spectrometer(self, device_id) -> Spectrometer:
-        log.debug(f"get_spectrometer: asked to get device_id {device_id}")
-        log.debug(f"get_spectrometer: currently have these spectrometer keys:")
-        for k in sorted(self.spectrometers, key=str):
-            log.debug(f"  {k}")
-
         return self.spectrometers.get(device_id,None)
 
     def is_autocolor(self) -> bool:

--- a/enlighten/Spectrometer.py
+++ b/enlighten/Spectrometer.py
@@ -4,7 +4,9 @@ import copy
 
 from .SpectrometerApplicationState import SpectrometerApplicationState
 
-from wasatch.SpectrometerState    import SpectrometerState
+from wasatch.SpectrometerState     import SpectrometerState
+from wasatch.AbstractUSBDevice     import AbstractUSBDevice
+from wasatch.MockUSBDevice         import MockUSBDevice
 
 log = logging.getLogger(__name__)
 
@@ -18,6 +20,46 @@ log = logging.getLogger(__name__)
 #
 # It is reasonable to ask whether ALL of SpectrometerApplicationState can be 
 # moved in here.
+#
+# @par Architecture
+#
+# \verbatim
+#                                       _______________         
+#                                      |   Controller  |        
+#                                      |_______________|        
+#                   +---------------------------^--------------------+
+#                  < >                                               |
+#         __________v___________                                _____v_____
+#        | WasatchDeviceWrapper | <------------.               | Multispec |
+#        |______________________|               `              |___________|
+#                   ^                           |                   < >
+#                   | .wrapper_worker           |                    | .spectrometers{}
+#            _______v_______                    |             _______v______
+#           | WrapperWorker |                   `--- .device | Spectrometer |
+#           |_______________|                                |______________|
+#                   ^
+#                   | .connected_device
+#            _______v_______
+#           | WasatchDevice |
+#           |_______________|
+#                   ^
+#                   | .hardware
+#     ______________v______________
+#    | FeatureIdentificationDevice | .device --> usb.core.Device
+#    |_____________________________|
+#                   ^
+#                   | .device_type
+#          _________v_________
+#         | AbstractUSBDevice |
+#         |___________________|
+#                  /_\ 
+#                   |
+#         +---------+-------+
+#  _______v_______   _______v_______ 
+# | MockUSBDevice | | RealUSBDevice |
+# |_______________| |_______________|
+#
+# \endverbatim
 #
 # @note fair bit of Controller can probably be moved into here
 # @note seems save to deepcopy and pass to plugins
@@ -40,7 +82,7 @@ class Spectrometer(object):
     def __init__(self, device, model_info):
         self.clear()
 
-        self.device = device
+        self.device = device # a WasatchDeviceWrapper
 
         self.device_id = self.device.device_id 
         self.settings = self.device.settings
@@ -198,3 +240,17 @@ class Spectrometer(object):
         log.info("change_device_setting[%s]: %s -> %s", device_id, setting, value)
         self.device.change_setting(setting, value)
 
+    def is_mock(self) -> bool:
+        return self.get_mock() is not None
+
+    def get_mock(self) -> MockUSBDevice:
+        device_type = self.get_device_type()
+        if device_type:
+            if isinstance(device_type, MockUSBDevice):
+                return device_type
+
+    def get_device_type(self) -> AbstractUSBDevice:
+        try:
+            return self.device.wrapper_worker.connected_device.hardware.device_type
+        except:
+            log.error(f"Spectrometer {self} doesn't seem to have an accessible device_type")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -31,22 +31,29 @@ def fixture():
     enlighten_app.run()
     yield enlighten_app
 
+# returns DeviceID
 def create_sim_spec(app,name,eeprom,eeprom_overrides=None,spectra_option=None):
+    log.info("create_sim_spec: instantiating MockUSBDevice")
     sim_spec = MockUSBDevice(name,eeprom,eeprom_overrides,spectra_option)
+    log.info(f"create_sim_spec: back from instantiating MockUSBDevice...sim_spec = {sim_spec}")
     if app.controller.multispec.is_disconnecting(sim_spec):
         app.controller.multispec.set_disconnecting(sim_spec, False)
     app.controller.connect_new(sim_spec)
     res = False
     @wait_until(timeout=5000)
     def check_connect():
+        log.info(f"create_sim_spec.check_connect: calling check_ready_initialize")
         app.controller.check_ready_initialize()
+        log.info(f"create_sim_spec.check_connect: calling Multispec.get_spectrometer({sim_spec})")
         spec = app.controller.multispec.get_spectrometer(sim_spec)
+        log.info(f"create_sim_spec.check_connect: Multispec.get_spectrometer returned spec = {spec}")
         if spec:
             return spec.device.device_id
     res = check_connect() # res = wait_until(timeout=9000)(check_connect)()
     spec_obj = app.controller.multispec.get_spectrometer(sim_spec)
     app.controller.attempt_reading(spec_obj)
     app.controller.attempt_reading(spec_obj)
+    log.info(f"create_sim_spec: returning result (device_id): {res}")
     return res
 
 def disconnect_spec(app,spec):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -33,27 +33,21 @@ def fixture():
 
 # returns DeviceID
 def create_sim_spec(app,name,eeprom,eeprom_overrides=None,spectra_option=None):
-    log.info("create_sim_spec: instantiating MockUSBDevice")
     sim_spec = MockUSBDevice(name,eeprom,eeprom_overrides,spectra_option)
-    log.info(f"create_sim_spec: back from instantiating MockUSBDevice...sim_spec = {sim_spec}")
     if app.controller.multispec.is_disconnecting(sim_spec):
         app.controller.multispec.set_disconnecting(sim_spec, False)
     app.controller.connect_new(sim_spec)
     res = False
     @wait_until(timeout=5000)
     def check_connect():
-        log.info(f"create_sim_spec.check_connect: calling check_ready_initialize")
         app.controller.check_ready_initialize()
-        log.info(f"create_sim_spec.check_connect: calling Multispec.get_spectrometer({sim_spec})")
         spec = app.controller.multispec.get_spectrometer(sim_spec)
-        log.info(f"create_sim_spec.check_connect: Multispec.get_spectrometer returned spec = {spec}")
         if spec:
             return spec.device.device_id
     res = check_connect() # res = wait_until(timeout=9000)(check_connect)()
     spec_obj = app.controller.multispec.get_spectrometer(sim_spec)
     app.controller.attempt_reading(spec_obj)
     app.controller.attempt_reading(spec_obj)
-    log.info(f"create_sim_spec: returning result (device_id): {res}")
     return res
 
 def disconnect_spec(app,spec):

--- a/test/test_usb.py
+++ b/test/test_usb.py
@@ -200,11 +200,6 @@ class TestUSB:
 
         @wait_until(timeout=2000)
         def check(expected_value):
-            # first make sure the command has actually made it downstream to the mock
-            # if f"MockUSBDevice.cmd_toggle_laser: setting {expected_value}" not in caplog.text:
-            #     return
-
-            # now make sure the mock was correctly updated
             mock = sim_spec_obj.get_mock()
             return mock.laser_enable == expected_value
 

--- a/test/test_usb.py
+++ b/test/test_usb.py
@@ -68,8 +68,14 @@ class TestUSB:
         if "exiting because of downstream poison-pill command from ENLIGHTEN" in caplog.text:
             return True
 
-    # description: a release test that checks the gui change results in the SPECTROMETER_SETTINGS integration time changing
+    # description: a release test that checks the gui change results in the 
+    #              SPECTROMETER_SETTINGS integration time changing 
     # author: Mark Zieg
+    #
+    # This is an example test that shows how to write tests which are validated 
+    # against spectrometer state within ENLIGHTEN (as opposed to within the Mock
+    # spectrometer itself).
+    #
     @pytest.mark.release
     def test_set_int_time_enlighten(self, app, caplog):
         sim_spec = create_sim_spec(app, "WP-00887", "WP-00887-mock.json")
@@ -94,8 +100,14 @@ class TestUSB:
         else:
             assert False, f"No sim_spec, received {sim_spec} for sim_spec"
 
-    # description: a release test that checks the GUI change results in the MOCK DEVICE integration time changing
+    # description: a release test that checks the GUI change results in the 
+    #              MOCK DEVICE integration time changing
     # author: Evan Dort
+    #
+    # This is an example test that shows how to write tests which are validated 
+    # against the Mock spectrometer (virtual hardware) in the Wasatch.PY driver, 
+    # as opposed to within ENLIGHTEN's "application state".
+    #
     @pytest.mark.release
     def test_set_int_time_mock(self, app, caplog):
         sim_spec = create_sim_spec(app, "WP-00887", "WP-00887-mock.json")
@@ -190,8 +202,8 @@ class TestUSB:
         @wait_until(timeout=2000)
         def check(expected_value):
             # first make sure the command has actually made it downstream to the mock
-            if f"MockUSBDevice.cmd_toggle_laser: setting {expected_value}" not in caplog.text:
-                return
+            # if f"MockUSBDevice.cmd_toggle_laser: setting {expected_value}" not in caplog.text:
+            #     return
 
             # now make sure the mock was correctly updated
             mock = sim_spec_obj.get_mock()
@@ -235,8 +247,14 @@ class TestUSB:
 
         @wait_until(timeout=3000)
         def check():
-            if sim_spec.detector_tec_enable:
-                return True
+            # if sim_spec.detector_tec_enable:
+            #     return True
+            # if f"MockUSBDevice.cmd_set_detector_tec_enable: setting {expected_value}" not in caplog.text:
+            #     return
+
+            # now make sure the mock was correctly updated
+            mock = sim_spec_obj.get_mock()
+            return mock.detector_tec_enable 
 
         sim_spec = create_sim_spec(app,"WP-00887","WP-00887-mock.json")
         sim_spec_obj = app.controller.multispec.get_spectrometer(sim_spec)
@@ -343,6 +361,3 @@ class TestUSB:
         res = check()
         assert res
         disconnect_spec(app,sim_spec)
-
-
-

--- a/test/test_usb.py
+++ b/test/test_usb.py
@@ -74,7 +74,26 @@ class TestUSB:
         #sim_spec = create_sim_spec(app,"SiG_785","EEPROM-EM-9c65d19f4c.json")
         @wait_until(timeout=3000)
         def check():
-            value = sim_spec_obj.device.device_id.int_time
+            # MZ: Question: should the enlighten.Spectrometer object returned by
+            # enlighten.Multispec.get_spectrometer() actually provide access to 
+            # the MockUSBDevice?  I kind of feel like no.  Not strongly, but I'd
+            # rather this test operate at the level of enlighten.Spectrometer.state.
+            #
+            # Yes this would be a better / stronger test if it were actually checking
+            # the MockUSBDevice.int_time parameter.  The question is whether ENLIGHTEN
+            # actually has access to that object, which is instantiated within by
+            # FeatureIdentificationDevice's ctor inside WrapperWorker's child thread.
+            #
+            # Historically, that object would not have been passed back through the
+            # multi-process queues.  I'm less clear on whether ENLIGHTEN has access
+            # to it now, in the multi-threaded architecture.
+            #
+            # This would benefit from an Entity-Relationship diagram :-)
+            #
+            # value = sim_spec_obj.device.device_id.int_time
+            value = sim_spec_obj.settings.state.integration_time_ms
+
+            log.info(f"test_set_int_time.check: value = {value}")
             if init_int+1 == value:
                 return value
         if sim_spec:

--- a/test/test_usb.py
+++ b/test/test_usb.py
@@ -84,7 +84,6 @@ class TestUSB:
         @wait_until(timeout=3000)
         def check():
             value = sim_spec_obj.settings.state.integration_time_ms
-            log.info(f"test_set_int_time_enlighten.check: value = {value}")
             return value
 
         if sim_spec:
@@ -247,12 +246,6 @@ class TestUSB:
 
         @wait_until(timeout=3000)
         def check():
-            # if sim_spec.detector_tec_enable:
-            #     return True
-            # if f"MockUSBDevice.cmd_set_detector_tec_enable: setting {expected_value}" not in caplog.text:
-            #     return
-
-            # now make sure the mock was correctly updated
             mock = sim_spec_obj.get_mock()
             return mock.detector_tec_enable 
 

--- a/test/test_usb.py
+++ b/test/test_usb.py
@@ -68,6 +68,7 @@ class TestUSB:
     @pytest.mark.release
     def test_set_int_time(self,app):
         sim_spec = create_sim_spec(app,"WP-00887","WP-00887-mock.json")
+        log.info(f"test_set_int_time: sim_spec = {sim_spec}")
         sim_spec_obj = app.controller.multispec.get_spectrometer(sim_spec)
         #log.info(f"{sim_spec}")
         #sim_spec = create_sim_spec(app,"SiG_785","EEPROM-EM-9c65d19f4c.json")


### PR DESCRIPTION
- Added enlighten.Spectrometer.get_mock() to simplify pytest creation
- Added caplog fixture to provide unique pytest assertions and provide conversational "waypoints"
- All "release" tests again passing (Mac and Windows)