### PR TITLE
dark-correct reference after-the-fact if necessary

### DIFF
--- a/enlighten/AbsorbanceFeature.py
+++ b/enlighten/AbsorbanceFeature.py
@@ -22,7 +22,7 @@ class AbsorbanceFeature:
         self.marquee        = marquee                
         self.transmission   = transmission
 
-    def process(self, processed_reading, settings) -> bool:
+    def process(self, processed_reading, settings, app_state) -> bool:
         """
         Computes absorbance from the current processed spectrum,
         then stores it back into 'processed.'
@@ -32,7 +32,7 @@ class AbsorbanceFeature:
         """
         pr = processed_reading
 
-        if not self.transmission.process(pr, settings):
+        if not self.transmission.process(pr, settings, app_state):
             log.error("can't compute absorbance w/o transmission")
             return False
 

--- a/enlighten/Controller.py
+++ b/enlighten/Controller.py
@@ -1932,15 +1932,15 @@ class Controller:
 
         if self.page_nav.using_reference():
             if self.page_nav.doing_transmission():
-                self.transmission.process(pr, settings)
+                self.transmission.process(pr, settings, spec.app_state)
             elif self.page_nav.doing_absorbance():
-                self.absorbance.process(pr, settings)
+                self.absorbance.process(pr, settings, spec.app_state)
 
         ########################################################################
         # non-reference techniques
         ########################################################################
 
-        if not self.page_nav.using_reference():
+        else:
 
             ####################################################################
             # Raman intensity correction

--- a/enlighten/TransmissionFeature.py
+++ b/enlighten/TransmissionFeature.py
@@ -31,7 +31,7 @@ class TransmissionFeature:
     # (if no dark is available, just use sample / reference)
     #
     # @returns True if ProcessedReading.processed successfully updated
-    def process(self, processed_reading, settings):
+    def process(self, processed_reading, settings, app_state):
         pr = processed_reading
 
         if pr.dark is None:
@@ -42,6 +42,11 @@ class TransmissionFeature:
         if ref is None:
             self.marquee.error("Please take reference")
             return False
+
+        # dark-correct reference if not already done
+        if not app_state.reference_is_dark_corrected:
+            ref = ref.copy()
+            ref -= pr.dark
 
         sample = pr.get_processed()
         if sample is None:


### PR DESCRIPTION
Allow customers to take their reference before their dark in reflectance / transmission mode.