### PR TITLE
Added N2, O2

### DIFF
--- a/enlighten/assets/example_data/raman_id_signatures/benigns.json
+++ b/enlighten/assets/example_data/raman_id_signatures/benigns.json
@@ -3,6 +3,18 @@
     "Type": "ENLIGHTEN Raman Compound ID Database",
     "Compounds": {
 
+        "Nitrogen": {
+            "Peaks": {
+                "2328.4": {}
+            }
+        },
+
+        "Oxygen": {
+            "Peaks": {
+                "1552.9": {}
+            }
+        },
+
         "Aspirin": {
             "Peaks": {
                 "322": {},

--- a/enlighten/assets/example_data/raman_id_signatures/benigns.json
+++ b/enlighten/assets/example_data/raman_id_signatures/benigns.json
@@ -79,15 +79,17 @@
         "Nitrogen": {
             "Peaks": {
                 "2328.4": {}
-            }
+            },
+            "Alias": "N2"
         },
 
         "Oxygen": {
             "Peaks": {
                 "1552.9": {}
-            }
+            },
+            "Alias": "O2"
         },
-        
+
         "Polystyrene": {
             "Peaks": {
                 "620.9": {},

--- a/enlighten/assets/example_data/raman_id_signatures/benigns.json
+++ b/enlighten/assets/example_data/raman_id_signatures/benigns.json
@@ -3,18 +3,6 @@
     "Type": "ENLIGHTEN Raman Compound ID Database",
     "Compounds": {
 
-        "Nitrogen": {
-            "Peaks": {
-                "2328.4": {}
-            }
-        },
-
-        "Oxygen": {
-            "Peaks": {
-                "1552.9": {}
-            }
-        },
-
         "Aspirin": {
             "Peaks": {
                 "322": {},
@@ -88,6 +76,18 @@
             "Alias": "IPA"
         },
 
+        "Nitrogen": {
+            "Peaks": {
+                "2328.4": {}
+            }
+        },
+
+        "Oxygen": {
+            "Peaks": {
+                "1552.9": {}
+            }
+        },
+        
         "Polystyrene": {
             "Peaks": {
                 "620.9": {},


### PR DESCRIPTION
Adding N2 and O2 to benigns.json is simple, so I wanted to make this change immediately available via a pull request, but there are a couple assumptions and areas that could undergo additional scrutiny. 

   1. - [x] I used common names Nitrogen, Oxygen to match other entries such as Isopropyl, Aspirin
2. - [x] I did ~not~ include "Alias" which could be "N2" and "O2" respectively
3. - [ ] I did not include "Type" to identify a peak as "Primary" or "Weak", modeled after Teflon, which is the only existing entry that has less than three peaks.
4. - [ ] There is not a sound entry. There are a few existing entries like this. Files like nitroglycerin.wav aren't mentioned in the local README.md, so I am not sure where to source more of them.