### PR TITLE
show laser excitation spinbox in Expert mode

### DIFF
--- a/enlighten/BusinessObjects.py
+++ b/enlighten/BusinessObjects.py
@@ -446,12 +446,10 @@ class BusinessObjects:
             parent                      = ctl.form,
 
             button_login                = sfu.pushButton_admin_login,
-            combo_view                 = sfu.comboBox_view,
+            combo_view                  = sfu.comboBox_view,
 
             oem_widgets                 = [ sfu.pushButton_write_eeprom, sfu.pushButton_importEEPROM, sfu.pushButton_exportEEPROM, sfu.pushButton_restore_eeprom, sfu.pushButton_reset_fpga ],
-            advanced_widgets            = [ sfu.doubleSpinBox_lightSourceWidget_excitation_nm,
-                                            sfu.label_lightSourceWidget_excitation_nm,
-                                            sfu.tabWidget_advanced_features ])
+            advanced_widgets            = [ sfu.tabWidget_advanced_features ])
 
         self.header("instantiating EEPROMWriter")
         ctl.eeprom_writer = EEPROMWriter(
@@ -503,6 +501,7 @@ class BusinessObjects:
             button_toggle               = sfu.pushButton_laser_toggle,
             frame                       = sfu.frame_lightSourceControl,
             lb_watchdog                 = sfu.label_laser_watchdog_sec,
+            lb_excitation               = sfu.label_lightSourceWidget_excitation_nm,
             spinbox_excitation          = sfu.doubleSpinBox_lightSourceWidget_excitation_nm, # not EEPROMEditor
             spinbox_power               = sfu.doubleSpinBox_laser_power,
             slider_power                = sfu.verticalSlider_laser_power,

--- a/enlighten/Controller.py
+++ b/enlighten/Controller.py
@@ -625,6 +625,7 @@ class Controller:
         # disable anything that shouldn't be on without a spectrometer
         # (could grow this considerably)
         for feature in [ self.accessory_control,
+                         self.laser_control,
                          self.raman_mode_feature,
                          self.raman_intensity_correction,
                          self.raman_shift_correction,

--- a/enlighten/scope/LaserControlFeature.py
+++ b/enlighten/scope/LaserControlFeature.py
@@ -33,6 +33,7 @@ class LaserControlFeature:
                  button_toggle,
                  frame,
                  lb_watchdog,
+                 lb_excitation,
                  spinbox_excitation,    # doubleSpinBox on Laser Control widget, not EEPROMEditor
                  spinbox_power,         # doubleSpinBox
                  slider_power,
@@ -53,6 +54,7 @@ class LaserControlFeature:
         self.button_toggle      = button_toggle
         self.frame              = frame
         self.lb_watchdog        = lb_watchdog
+        self.lb_excitation      = lb_excitation
         self.spinbox_excitation = spinbox_excitation
         self.spinbox_power      = spinbox_power
         self.slider_power       = slider_power
@@ -126,6 +128,7 @@ class LaserControlFeature:
 
         settings = spec.settings
         has_laser = settings.eeprom.has_laser
+        doing_expert = self.page_nav.doing_expert()
 
         self.frame.setVisible(has_laser)
         if not has_laser:
@@ -141,6 +144,9 @@ class LaserControlFeature:
                 self.configure_laser_power_controls_mW()
             else:
                 self.configure_laser_power_controls_percent()
+
+        self.spinbox_excitation.setVisible(doing_expert)
+        self.lb_excitation     .setVisible(doing_expert)
 
         self.configure_watchdog()
 


### PR DESCRIPTION
This used to be hidden through Authentication to prevent casual users from tripping over it, but now that we have a readily accessible Expert mode, this feature should be made easier to access.