### PR TITLE
set tableview to not stretch

### DIFF
--- a/enlighten/Plugins/PluginController.py
+++ b/enlighten/Plugins/PluginController.py
@@ -899,6 +899,11 @@ class PluginController:
         log.debug("creating output table widget")
         self.table_view = QtWidgets.QTableView()
         self.table_view.setAccessibleName("Pandas Output")
+
+        # set stretch factor of scope to 1
+        # tableview stretch defaults to 0, so it does not stretch
+        self.layout_graphs.setRowStretch(1, 1)       
+
         self.layout_graphs.addWidget(self.table_view, 3, 0, 1, 3)
         self.layout_graphs.setRowMinimumHeight(3, 100)
 


### PR DESCRIPTION
![image](https://github.com/WasatchPhotonics/ENLIGHTEN/assets/124081765/68f8756e-c93e-4129-86a0-4891e8883d5b)

Now, when the vertical height of the window is large, the TableView will not stretch to take up so much of the screen space.

It is not yet resizable. The table is added to the view in `create_output_table` from PluginController.py. The parent widget is a QGridLayout which does not support manual resizing. Substituting with a QSplitter should add the manual resize support.

The decision to use QGridLayout was made so we would have several spaces for additional widgets (9 total) and we set the scope in the middle slot and the tableview in the bottom slot. If we instead use QSplitter's it is still possible to add more widgets, but the overall shape will be different--and manual resize will be supported.

Before changing the parent widget of scope and tableview, some things to consider:
- check references to `sfu.layout_scope_capture_graphs`. There are currently two.
- change the loader of tableview (create_output_table:PluginController.py)
- change the unloader of tableview. There isn't one yet.
- `sfu.layout_scope_capture_graphs` is defined in the enlighten_layout.ui file, whereas tableview (and probably scope as well) are defined in .py source files