### PR TITLE
conda deactivate + bootstrap ui

### DIFF
--- a/scripts/bootstrap.bat
+++ b/scripts/bootstrap.bat
@@ -61,6 +61,12 @@ if "%1" == "test" (
 )
 
 REM DEFINE CUSTOM ACTION HERE
+if "%1" == "ui" (
+    set "regenerate_qt=1"
+    goto args_parsed
+)
+
+REM DEFINE CUSTOM ACTION HERE
 if "%1" == "custom" (
     set "rebuild_env=0"
     set "clear_pyinst_appdata=0"
@@ -246,6 +252,8 @@ echo %date% %time% ======================================================
 echo %date% %time% Activating environment
 echo %date% %time% ======================================================
 echo.
+REM deactivate before activate in-case user runs `scripts\bootstrap activate` multiple times
+call deactivate
 REM Use "source" from bash, "call" from batch and neither from Cmd
 call activate conda_enlighten3
 if %errorlevel% neq 0 goto script_failure

--- a/scripts/bootstrap.bat
+++ b/scripts/bootstrap.bat
@@ -60,7 +60,6 @@ if "%1" == "test" (
     goto args_parsed
 )
 
-REM DEFINE CUSTOM ACTION HERE
 if "%1" == "ui" (
     set "regenerate_qt=1"
     goto args_parsed


### PR DESCRIPTION
### conda deactivate before activate

It gives an annoying deprecation message, but it avoids this scenario:

```
scripts\bootstrap activate
REM a lot of time passes
REM ...
REM did I activate? better do it again to be safe
run
```

And then it crashes because it was over activated.

Now this required activation step can be repeated to one's heart's content.

### bootstrap ui

After pulling updates I will try the lightest-weight way to run
```
scripts\bootstrap activate
run
```

If it crashes because of a UI element, then I'll figure I need to run `rebuild_resources.sh`
It's a lot easier to up arrow a couple times in the terminal and change 'activate' to 'ui', instead of typing out

```
sh scripts\rebuild_resources.sh
```

So... this is a convenience too.