### PR TITLE
Fixes to "Save"

### DIFF
--- a/README_CHANGELOG.md
+++ b/README_CHANGELOG.md
@@ -2,8 +2,9 @@
 
 # 4.0 GUI Refactoring
 
-- 2023-06-05 4.0.12
+- 2023-06-?? 4.0.12
     - fixed Configuration defaults
+    - warn when saving but no formats selected
 - 2023-05-15 4.0.11
     - added collated export
     - invert x-axis for 1064XL

--- a/README_CHANGELOG.md
+++ b/README_CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # 4.0 GUI Refactoring
 
+- 2023-06-05 4.0.12
+    - fixed Configuration defaults
 - 2023-05-15 4.0.11
     - added collated export
     - invert x-axis for 1064XL

--- a/enlighten/common.py
+++ b/enlighten/common.py
@@ -13,7 +13,7 @@ application.
       can be modules (files) within it
 """
 
-VERSION = "4.0.11"
+VERSION = "4.0.12"
 
 """ ENLIGHTEN's application version number (checked by scripts/deploy and bootstrap.bat) """
 class Techniques(IntEnum):

--- a/enlighten/file_io/Configuration.py
+++ b/enlighten/file_io/Configuration.py
@@ -86,7 +86,7 @@ class Configuration(object):
 
         self.load_defaults()
         self.stub_missing()
-        self.stub_test()
+        self.stub_test() # MZ: I don't think this belongs in Configuration
 
         try:
             self.reload()
@@ -341,11 +341,15 @@ class Configuration(object):
             return section in self.defaults
 
     def has_option(self, section, option):
+        # any option which is defaulted will always indicate "has_option -> true";
+        # .ini file may override value, but can't change that there IS a value
+        if section in self.defaults and option in self.defaults[section]:
+            return True
+
+        # non-default options may or may not be defined
         if self.config and self.config.has_section(section):
             return self.config.has_option(section, option)
-        else:
-            if section in self.defaults:
-                return option in self.defaults[section]
+
         return False            
 
     def process_color(self, value):

--- a/enlighten/measurement/Measurement.py
+++ b/enlighten/measurement/Measurement.py
@@ -684,20 +684,30 @@ class Measurement(object):
 
     ## @todo cloud etc
     def save(self):
+        saved = False
         if self.save_options.save_csv():
             self.save_csv_file()
+            saved = True
 
         if self.save_options.save_text():
             self.save_txt_file()
+            saved = True
 
         if self.save_options.save_excel():
             self.save_excel_file()
+            saved = True
 
         if self.save_options.save_json():
             self.save_json_file()
+            saved = True
 
         if self.save_options.save_spc():
             self.save_spc_file()
+            saved = True
+
+        if not saved:
+            if self.measurements:
+                self.measurements.marquee.error("No save formats selected -- spectrum not saved to disk")
 
     def save_csv_file(self):
         if self.save_options is not None and self.save_options.save_by_row():

--- a/enlighten/measurement/SaveOptions.py
+++ b/enlighten/measurement/SaveOptions.py
@@ -195,9 +195,7 @@ class SaveOptions():
         self.le_note            .setText   (re.sub(",", "", self.config.get(s, "note")))
 
     def init_checkbox(self, cb, option):
-        log.debug(f"init_checkbox (option {option})")
         value = self.config.get_bool("save", option)
-        log.debug(f"init_checkbox setting {value} to {cb}")
         cb.setChecked(value)
 
     ## Update widgets and config state when:
@@ -212,9 +210,7 @@ class SaveOptions():
         # decide which widgets should be ENABLED (not checked)
         ########################################################################
 
-        log.debug("update_widgets: checking save_csv")
         save_csv = self.save_csv()
-        log.debug(f"update_widgets: save_csv = {save_csv}")
 
         # these widgets are dependent on the CSV checkbox
         self.rb_by_row.setEnabled(save_csv)
@@ -248,7 +244,6 @@ class SaveOptions():
         # update config
         ########################################################################
 
-        log.debug(f"update_widgets: setting config from current checkbox state")
         s = "save"
         self.config.set(s, "order", "row" if self.save_by_row() else "col")
         self.config.set(s, "collated",           self.save_collated())

--- a/enlighten/measurement/SaveOptions.py
+++ b/enlighten/measurement/SaveOptions.py
@@ -195,7 +195,9 @@ class SaveOptions():
         self.le_note            .setText   (re.sub(",", "", self.config.get(s, "note")))
 
     def init_checkbox(self, cb, option):
+        log.debug(f"init_checkbox (option {option})")
         value = self.config.get_bool("save", option)
+        log.debug(f"init_checkbox setting {value} to {cb}")
         cb.setChecked(value)
 
     ## Update widgets and config state when:
@@ -210,7 +212,9 @@ class SaveOptions():
         # decide which widgets should be ENABLED (not checked)
         ########################################################################
 
+        log.debug("update_widgets: checking save_csv")
         save_csv = self.save_csv()
+        log.debug(f"update_widgets: save_csv = {save_csv}")
 
         # these widgets are dependent on the CSV checkbox
         self.rb_by_row.setEnabled(save_csv)
@@ -244,6 +248,7 @@ class SaveOptions():
         # update config
         ########################################################################
 
+        log.debug(f"update_widgets: setting config from current checkbox state")
         s = "save"
         self.config.set(s, "order", "row" if self.save_by_row() else "col")
         self.config.set(s, "collated",           self.save_collated())


### PR DESCRIPTION
Changes:

- Configuration defaults work again (apparently broke at some point, including no longer defaulting SaveOptions.format_csv to True on new enlighten.ini)
- Warn user if "saving" spectra but no formats selected