### PR TITLE
Fix various reported Save and Export issues

### DIFF
--- a/README_CHANGELOG.md
+++ b/README_CHANGELOG.md
@@ -5,6 +5,7 @@
 - 2023-06-?? 4.0.12
     - fixed Configuration defaults
     - warn when saving but no formats selected
+    - fixed load-then-export
 - 2023-05-15 4.0.11
     - added collated export
     - invert x-axis for 1064XL

--- a/README_CHANGELOG.md
+++ b/README_CHANGELOG.md
@@ -10,6 +10,8 @@
     - always save all rows of column-ordered CSV spectra regardless of ROI
     - output "NA" rather than 0 for values omitted due to ROI or spectral range
     - use prefix and suffix in export filenames
+    - stop forcing loaded data to lowercase
+    - improved data consistency in loaded CSVs
 - 2023-05-15 4.0.11
     - added collated export
     - invert x-axis for 1064XL

--- a/README_CHANGELOG.md
+++ b/README_CHANGELOG.md
@@ -7,6 +7,8 @@
     - warn when saving but no formats selected
     - fixed load-then-export
     - updated Write EEPROM tooltip
+    - always save all rows of column-ordered CSV spectra regardless of ROI
+    - output "NA" rather than 0 for values omitted due to ROI or spectral range
 - 2023-05-15 4.0.11
     - added collated export
     - invert x-axis for 1064XL

--- a/README_CHANGELOG.md
+++ b/README_CHANGELOG.md
@@ -9,6 +9,7 @@
     - updated Write EEPROM tooltip
     - always save all rows of column-ordered CSV spectra regardless of ROI
     - output "NA" rather than 0 for values omitted due to ROI or spectral range
+    - use prefix and suffix in export filenames
 - 2023-05-15 4.0.11
     - added collated export
     - invert x-axis for 1064XL

--- a/enlighten/Controller.py
+++ b/enlighten/Controller.py
@@ -1106,9 +1106,9 @@ class Controller:
 
         if self.save_options.save_all_spectrometers():
             for spec in self.multispec.get_spectrometers():
-                self.measurements.create_from_spectrometer(spec=spec, view=view)
+                self.measurements.create_from_spectrometer(spec=spec)
         else:
-            self.measurements.create_from_spectrometer(spec=self.current_spectrometer(), view=view)
+            self.measurements.create_from_spectrometer(spec=self.current_spectrometer())
 
     # ##########################################################################
     # miscellaneous callbacks

--- a/enlighten/device/EEPROMWriter.py
+++ b/enlighten/device/EEPROMWriter.py
@@ -57,7 +57,7 @@ class EEPROMWriter(object):
             box.setWindowTitle(label)
             box.setText("Do you wish to update your EEPROM? " + 
                 "Misconfiguration could 'brick' your spectrometer and require manufacturer RMA. ")
-            box.setInformativeText("Incorrect usage of the EEPROM voids warranty.")
+            box.setInformativeText("Incorrect usage of the EEPROM may void warranty.")
             box.setStandardButtons(QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.Cancel)
 
             retval = box.exec_()

--- a/enlighten/measurement/Measurement.py
+++ b/enlighten/measurement/Measurement.py
@@ -754,10 +754,10 @@ class Measurement(object):
         if field == "temperature":               return self.processed_reading.reading.detector_temperature_degC if self.processed_reading.reading is not None else -99
         if field == "technique":                 return self.technique
         if field == "baseline correction algo":  return self.baseline_correction_algo
-        if field == "ccd c0":                    return wavecal[0]
-        if field == "ccd c1":                    return wavecal[1]
-        if field == "ccd c2":                    return wavecal[2]
-        if field == "ccd c3":                    return wavecal[3]
+        if field == "ccd c0":                    return 0 if len(wavecal) < 1 else wavecal[0] 
+        if field == "ccd c1":                    return 0 if len(wavecal) < 2 else wavecal[1]
+        if field == "ccd c2":                    return 0 if len(wavecal) < 3 else wavecal[2]
+        if field == "ccd c3":                    return 0 if len(wavecal) < 4 else wavecal[3]
         if field == "ccd c4":                    return 0 if len(wavecal) < 5 else wavecal[4]
         if field == "ccd offset":                return self.settings.eeprom.detector_offset # even
         if field == "ccd gain":                  return self.settings.state.gain_db if self.settings.is_sig() else self.settings.eeprom.detector_gain # even

--- a/enlighten/measurement/Measurement.py
+++ b/enlighten/measurement/Measurement.py
@@ -1189,10 +1189,6 @@ class Measurement(object):
 
             for pixel in range(pixels):
 
-                # don't output cropped rows
-                if roi is not None and not roi.contains(pixel):
-                    continue
-
                 values = []
                 if self.save_options is not None:
                     if self.save_options.save_pixel()      : values.append(pixel)
@@ -1208,13 +1204,18 @@ class Measurement(object):
                             values.append(formatted(precision, pr.processed_vignetted, pixel - roi.start))
                         else:
                             # this is a cropped pixel, so arguably it could be None (,,), @na, -1
-                            # or various other things, but this will probably break the least downstream
-                            values.append(0)
+                            # or 0, or various other things, but consensus converged on "NA"
+                            values.append("NA")
 
+                    # Note that we're always output raw/dark/ref (if selected), regardless of ROI (makes sense).
+                    # I'm less sure why we don't interpolate raw/dark/ref, or how this comes out in the file if
+                    # we are interpolating...
                     if self.save_options.save_raw()        : values.append(formatted(precision, pr.raw,       pixel))
                     if self.save_options.save_dark()       : values.append(formatted(precision, pr.dark,      pixel))
                     if self.save_options.save_reference()  : values.append(formatted(precision, pr.reference, pixel))
                 else:
+                    # MZ: I don't remember the use-case for this.  May involve 
+                    # this class being imported and used by an outside script?
                     values.append(formatted(2, wavenumbers,  pixel))
                     values.append(formatted(precision, pr.processed, pixel)) 
 

--- a/enlighten/measurement/Measurement.py
+++ b/enlighten/measurement/Measurement.py
@@ -217,7 +217,7 @@ class Measurement(object):
                            'Declared Score',
                            'Scan Averaging',
                            'Boxcar',
-                           'View',
+                           'Technique',
                            'Baseline Correction Algo',
                            'ROI Pixel Start',
                            'ROI Pixel End',
@@ -235,7 +235,6 @@ class Measurement(object):
                            'Device ID',
                            'FW Version',
                            'FPGA Version',
-                           'Note',
                            'Prefix',
                            'Suffix',
                            'Plugin Name']
@@ -277,7 +276,7 @@ class Measurement(object):
             save_options        = None,
             settings            = None,
             source_pathname     = None,
-            view                = None,
+            technique           = None,
             timestamp           = None,
             spec                = None,
             measurement         = None,
@@ -316,7 +315,7 @@ class Measurement(object):
             # the ProcessedReading. (Taking a deepcopy, because with plug-ins who
             # knows...)
             self.processed_reading  = copy.deepcopy(spec.app_state.processed_reading)
-            self.view               = spec.app_state.technique_name
+            self.technique          = spec.app_state.technique_name
             self.timestamp          = datetime.datetime.now()
             self.baseline_correction_algo = spec.app_state.baseline_correction_algo
 

--- a/enlighten/measurement/Measurement.py
+++ b/enlighten/measurement/Measurement.py
@@ -1,4 +1,4 @@
-import datetime 
+import datetime
 import logging
 import numpy
 import xlwt
@@ -22,9 +22,9 @@ log = logging.getLogger(__name__)
 
 ##
 # Encapsulates a single saved measurement from one spectrometer, comprising
-# a ProcessedReading (optionally containing the original Reading object that 
-# generated it), metadata (Settings), as well as a ThumbnailWidget for display 
-# on the capture bar.  Note that other than the ProcessedReading, 
+# a ProcessedReading (optionally containing the original Reading object that
+# generated it), metadata (Settings), as well as a ThumbnailWidget for display
+# on the capture bar.  Note that other than the ProcessedReading,
 # SpectrometerApplicationState is NOT retained in the Measurement.
 #
 # A Measurement object is created when:
@@ -36,16 +36,16 @@ log = logging.getLogger(__name__)
 # If a Measurement is loaded from disk, it will not contain the original Reading
 # object.  Also, the metadata may be limited.
 #
-# If a Measurement is generated live, it will also have a reference to the 
+# If a Measurement is generated live, it will also have a reference to the
 # spectrometer which generated it.
 #
-# Regardless of whether the Measurement was generated from a live capture 
-# (Acquire) or loaded from disk, a ThumbnailWidget will be generated (not 
+# Regardless of whether the Measurement was generated from a live capture
+# (Acquire) or loaded from disk, a ThumbnailWidget will be generated (not
 # necessarily instantly) for visualization.
 #
 # As some Measurements may be displayed in different x-axis coordinates, we need
 # to store the "current / selected / displayed" x-axis for the Measurement. I'm
-# tentatively thinking to do that in the ThumbnailWidget, as it's kind of an 
+# tentatively thinking to do that in the ThumbnailWidget, as it's kind of an
 # attribute of the trace, but we'll see.
 #
 # I am not sure whether we really need separate Thumbnail and ThumbnailWidget
@@ -57,27 +57,27 @@ log = logging.getLogger(__name__)
 # different attributes and controlled background timing, a MeasurementFactory
 # is provided to separately encapsulate the process of construction.
 #
-# Each Measurement has a .measurement_id, which is permanent.  The id is used 
-# as the default label attribute (both for file basenames and for on-screen 
-# display), but the label may be subsequently changed by the user.  
+# Each Measurement has a .measurement_id, which is permanent.  The id is used
+# as the default label attribute (both for file basenames and for on-screen
+# display), but the label may be subsequently changed by the user.
 #
 # @par Pathnames and Persistence
 #
-# There is no simple .pathname attribute for the Measurement, as one Measurement 
-# may have been saved to any or all of several different file types.  
-# 
-# AT PRESENT, it is assumed that the creation of a Measurement will include 
-# saving the Measurement to one or more output files at creation, but this is not 
-# a long-term requirement (we may decide to support "session traces" which are 
+# There is no simple .pathname attribute for the Measurement, as one Measurement
+# may have been saved to any or all of several different file types.
+#
+# AT PRESENT, it is assumed that the creation of a Measurement will include
+# saving the Measurement to one or more output files at creation, but this is not
+# a long-term requirement (we may decide to support "session traces" which are
 # never actually persisted to disk; Spectrasuite and OceanView have these).
 #
-# There is a .pathnames set which aggregates all the pathnames which are known 
-# related to this Measurement, though it is not guaranteed complete in the case 
+# There is a .pathnames set which aggregates all the pathnames which are known
+# related to this Measurement, though it is not guaranteed complete in the case
 # of loaded files from other sessions.  (Ideally all such files would contain
-# the original measurement_id somewhere within them, though not necessarily in 
+# the original measurement_id somewhere within them, though not necessarily in
 # the pathname.)
 #
-# If a Measurement has been deserialized from disk, it will have a 
+# If a Measurement has been deserialized from disk, it will have a
 # .source_pathname attribute to indicate the source file from which it was
 # instantiated.
 #
@@ -90,21 +90,21 @@ log = logging.getLogger(__name__)
 # @par Renaming Measurements
 #
 # Renaming Measurements is a potentially thorny issue.  Early versions of
-# ENLIGHTEN renamed the output file(s) when you changed the label of on-screen 
+# ENLIGHTEN renamed the output file(s) when you changed the label of on-screen
 # thumbnail, and customers wish to retain that ability (ticket from 2019-07-19).
 #
-# However, there is all kinds of ugliness down this hole: 
+# However, there is all kinds of ugliness down this hole:
 #
-# - What if you were appending measurements to one big CSV? 
-# - What if you loaded the measurement for comparison from archival spectra? 
+# - What if you were appending measurements to one big CSV?
+# - What if you loaded the measurement for comparison from archival spectra?
 # - What if you loeaded the measurement from a big export file?
 #
 # My current decision is that we will retain the historical ability to rename
 # any file(s) saved from the given Measurement IFF the files were CREATED
-# by the CURRENT ENLIGHTEN session; OR if the spectrum was loaded from a 
+# by the CURRENT ENLIGHTEN session; OR if the spectrum was loaded from a
 # single file (not an export or appended collection).
 #
-# This distinction is made when Measurements are loaded or saved, and 
+# This distinction is made when Measurements are loaded or saved, and
 # tracked via a renameable_files list.  It's not as simple as checking
 # whether the spectrum was created or loaded, because it matters what
 # type of file it was loaded from, or which type of file it was saved to.
@@ -118,7 +118,7 @@ log = logging.getLogger(__name__)
 #
 # Also, relabeling the Measurement on-screen, and even renaming the underlying
 # file artifacts DOES NOT re-write or update the file contents.  The "label"
-# field in the file metadata is not updated.  It would not be particularly hard 
+# field in the file metadata is not updated.  It would not be particularly hard
 # to re-save the file, but this seems like it would have many risks if a newer
 # version of ENLIGHTEN changed the file format, or if there had been extra data
 # in the file (ignored during a load operation, or added by the user post-save)
@@ -126,7 +126,7 @@ log = logging.getLogger(__name__)
 #
 # @par Thumbnails and resources
 #
-# Originally, ENLIGHTEN had no "Measurements", only "Thumbnails" -- the 
+# Originally, ENLIGHTEN had no "Measurements", only "Thumbnails" -- the
 # spectra was literally stored (only) as the y-values of the thumbnail
 # graph, with no x-axis, no metadata etc.  So it was an improvement to
 # move forward to "Measurements with Thumbnails".  But there is a resource
@@ -138,8 +138,8 @@ log = logging.getLogger(__name__)
 # on scroll events (similar to a Swift TableView, where cells are populated
 # as they scroll into view, and are released when offscreen).
 #
-# And possibly move away from the heavy "Widget" (with a couple Frames, 
-# Buttons, the pyqtgraph etc) to a simpler table or tree view which would 
+# And possibly move away from the heavy "Widget" (with a couple Frames,
+# Buttons, the pyqtgraph etc) to a simpler table or tree view which would
 # probably use less memory.
 #
 # For now, I'm compromising by treating the on-screen thumbnails as a ringbuffer,
@@ -147,7 +147,7 @@ log = logging.getLogger(__name__)
 # limit.
 #
 # Note that the MeasurementFactory automatically saves new Measurements to disk
-# (per SaveOptions) as they are created from Spectrometers, BEFORE they are 
+# (per SaveOptions) as they are created from Spectrometers, BEFORE they are
 # handed to Measurements for addition to the Thumbnail bar.  The process of
 # creating a Measurement (from Spectrometer) and saving it to disk is atomic,
 # so there is no need to worry that automatic deletion of Measurements for
@@ -155,11 +155,11 @@ log = logging.getLogger(__name__)
 #
 # @par Exploits
 #
-# It is ASSUMED that the user used the same Settings (integration time, boxcar 
+# It is ASSUMED that the user used the same Settings (integration time, boxcar
 # smoothing, scan averaging etc) when taking the 'raw', 'dark' and 'reference'
 # component spectra in generation of the 'processed' component.  Only a single
 # Settings object is retained for the entire ProcessedReading, which is copied
-# when the Measurement is created.  
+# when the Measurement is created.
 #
 # That is, if the user does something like this, the wrong integration time would
 # be stored with the Measurement:
@@ -169,7 +169,7 @@ log = logging.getLogger(__name__)
 # 3. set integration time 200ms
 # 4. click "Acquire" to save the current on-screen (paused) measurement
 #
-# There are various ways we could address this weakness (e.g., snap a Deep Copy 
+# There are various ways we could address this weakness (e.g., snap a Deep Copy
 # of Settings on pause()), but it's not a priority at this time.
 #
 # @todo more robust / defined behavior with duplicate labels across Measurements
@@ -177,7 +177,7 @@ log = logging.getLogger(__name__)
 class Measurement(object):
 
     ##
-    # These appear in legacy saved spectra files as-written (Dash format), so 
+    # These appear in legacy saved spectra files as-written (Dash format), so
     # don't casually screw with them (could break customer applications).
     #
     # Note that all are scalars (no lists).
@@ -201,7 +201,7 @@ class Measurement(object):
                          'Laser Temperature',
                          'Pixel Count']
     CSV_HEADER_FIELDS_SET = set(CSV_HEADER_FIELDS)
-    
+
     ## These CSV_HEADER_FIELDS only need to be used for row-ordered files
     ROW_ONLY_FIELDS = ['Blank', 'Line Number']
 
@@ -239,7 +239,7 @@ class Measurement(object):
                            'Prefix',
                            'Suffix',
                            'Plugin Name']
-                           
+
     EXTRA_HEADER_FIELDS_SET = set(EXTRA_HEADER_FIELDS)
 
     def clear(self):
@@ -250,7 +250,7 @@ class Measurement(object):
         self.declared_score           = 0
         self.label                    = None
         self.measurement_id           = None
-        self.measurements             = None 
+        self.measurements             = None
         self.processed_reading        = None
         self.renamable_files          = set()
         self.renamed_manually         = False
@@ -272,7 +272,7 @@ class Measurement(object):
     #
     # - with spec (take latest from that Spectrometer)
     # - with source_pathname (deserializing from disk)
-    def __init__(self, 
+    def __init__(self,
             processed_reading   = None,
             save_options        = None,
             settings            = None,
@@ -294,11 +294,11 @@ class Measurement(object):
             log.debug("instantiating from spectrometer %s", str(spec))
             self.spec = spec
 
-            # Use deepcopy() to ensure that subsequent changes to integration 
-            # time, laser power, excitation etc do not retroactively change the 
-            # historical state of the shared Spectrometer objects.  This also 
-            # ensures that "live" Measurements always have a copy of the Settings 
-            # of the spectrometer from which they were collected (including 
+            # Use deepcopy() to ensure that subsequent changes to integration
+            # time, laser power, excitation etc do not retroactively change the
+            # historical state of the shared Spectrometer objects.  This also
+            # ensures that "live" Measurements always have a copy of the Settings
+            # of the spectrometer from which they were collected (including
             # EEPROM etc).  It also helps with the case when a spectrometer
             # was disconnected (and optionally reconnected) after the Measurement
             # was saved, but before it was exported.
@@ -309,10 +309,10 @@ class Measurement(object):
 
             # Copy things we want from SpectrometerApplicationState.
             #
-            # Original thought was to deepcopy SpectrometerApplicationState, but 
-            # the waterfall instances could get large.  And has duplicates of 
-            # reference and dark, plus SIX RollingDataSet histories of detector 
-            # and laser temperature.  For now, assuming we DON'T, and just taking 
+            # Original thought was to deepcopy SpectrometerApplicationState, but
+            # the waterfall instances could get large.  And has duplicates of
+            # reference and dark, plus SIX RollingDataSet histories of detector
+            # and laser temperature.  For now, assuming we DON'T, and just taking
             # the ProcessedReading. (Taking a deepcopy, because with plug-ins who
             # knows...)
             self.processed_reading  = copy.deepcopy(spec.app_state.processed_reading)
@@ -321,7 +321,7 @@ class Measurement(object):
             self.baseline_correction_algo = spec.app_state.baseline_correction_algo
 
         elif source_pathname:
-            log.debug("instantiating from source pathname %s", source_pathname)            
+            log.debug("instantiating from source pathname %s", source_pathname)
             self.processed_reading  = processed_reading
             self.source_pathname    = source_pathname
             self.timestamp          = timestamp
@@ -356,14 +356,14 @@ class Measurement(object):
         m.thumbnail_widget = None
         m.settings = copy.deepcopy(self.settings)
         m.processed_reading = copy.deepcopy(self.processed_reading)
-        
+
         return m
 
     ##
-    # This is experimental.  Eventually we want to be able to load Measurements 
-    # saved as JSON.  We should also be able to receive externally-generated 
+    # This is experimental.  Eventually we want to be able to load Measurements
+    # saved as JSON.  We should also be able to receive externally-generated
     # Measurements sent via JSON via the External API.  This is reasonably key
-    # to both.  Also it's handy to use this as a free-form intermediate format 
+    # to both.  Also it's handy to use this as a free-form intermediate format
     # for parsing external formats like SPC.
     def init_from_dict(self, d):
 
@@ -391,8 +391,8 @@ class Measurement(object):
             self.processed_reading.processed_vignetted = self.processed_reading.processed
 
     ##
-    # We presumably loaded a measurement from disk, reprocessed it, and are now 
-    # replacing the contents of the Measurement object with the reprocessed 
+    # We presumably loaded a measurement from disk, reprocessed it, and are now
+    # replacing the contents of the Measurement object with the reprocessed
     # spectra, preparatory to re-saving (with a new timestamp and measurement_id.
     def replace_processed_reading(self, pr):
         self.processed_reading = pr
@@ -407,7 +407,7 @@ class Measurement(object):
         self.plugin_name = text
 
     def generate_id(self):
-        # It is unlikely that the same serial number will ever generate multiple 
+        # It is unlikely that the same serial number will ever generate multiple
         # measurements at the same timestamp in microseconds.
         sn = self.settings.eeprom.serial_number
 
@@ -435,7 +435,7 @@ class Measurement(object):
                 self.label += " %s" % self.measurements.factory.label_suffix
                 # log.debug("applying label_suffix (%s): %s", self.measurements.factory.label_suffix, self.label)
 
-                # this complicates saving from multiple spectrometers 
+                # this complicates saving from multiple spectrometers
                 # during batch collection
                 self.measurements.factory.label_suffix = None
 
@@ -510,15 +510,15 @@ class Measurement(object):
     ##
     # Display on the graph, if not already shown.
     def display(self):
-        if self.thumbnail_widget is not None: 
+        if self.thumbnail_widget is not None:
             self.thumbnail_widget.add_curve_to_graph()
 
-    ## 
-    # Release any resources associated with this Measurement.  Note that this 
+    ##
+    # Release any resources associated with this Measurement.  Note that this
     # will automatically delete the ThumbnailWidget from its parent layout (if
     # emplaced), and mark the object tree for garbage collection within PySide/Qt.
     def delete(self, from_disk=False, update_parent=False):
-        log.debug("deleting Measurement %s (from_disk %s, update_parent %s)", 
+        log.debug("deleting Measurement %s (from_disk %s, update_parent %s)",
             self.measurement_id, from_disk, update_parent)
 
         if from_disk:
@@ -529,17 +529,17 @@ class Measurement(object):
                 except:
                     pass
             self.renamable_files = set()
-                
+
         if update_parent:
             # This deletion request came from within the Measurement (presumably
             # from the ThumbnailWidget's Trash or Erase icons), so re-invoke the
-            # deletion request through our parent, so that parent resources are 
-            # likewise deleted.  We do NOT need to pass the from_disk flag, as 
-            # we've already executed that, and we haven't given Measurements the 
+            # deletion request through our parent, so that parent resources are
+            # likewise deleted.  We do NOT need to pass the from_disk flag, as
+            # we've already executed that, and we haven't given Measurements the
             # ability to pass that down anyway.
             #
             # MZ: this feels a bit kludgy?
-            
+
             if self.measurements is not None:
                 self.measurements.delete_measurement(measurement=self)
                 return
@@ -575,7 +575,7 @@ class Measurement(object):
         if self.thumbnail_widget:
             self.thumbnail_widget.rename(label)
             was_displayed = self.thumbnail_widget.is_displayed
-            self.thumbnail_widget.remove_curve_from_graph() 
+            self.thumbnail_widget.remove_curve_from_graph()
 
         # if they removed the label, nothing more to do
         if label is None:
@@ -599,26 +599,26 @@ class Measurement(object):
         self.save()
 
     ##
-    # The measurement has been relabled (say, "cyclohexane").  So if 
-    # pathnames contains "old.csv" and "old.xls", we want to rename them to 
-    # "cyclohexane.csv" and "cyclohexane.xls".  However, if those files 
+    # The measurement has been relabled (say, "cyclohexane").  So if
+    # pathnames contains "old.csv" and "old.xls", we want to rename them to
+    # "cyclohexane.csv" and "cyclohexane.xls".  However, if those files
     # already exist, we don't want to overwrite them (maybe the user is
     # looking at a lot of cyclohexane).  So if cyclohexane.csv already
     # exists, just make cyclohexane-1.csv, etc.  Whatever number we pick,
     # apply it to all the pathnames (cyclohexane-1.xls, even if there wasn't
     # already a cyclohexane.xls).
     #
-    # Also note that there are at least four ways this Measurement could have been 
+    # Also note that there are at least four ways this Measurement could have been
     # instantiated:
-    # 1. It could have been loaded from ONE individual CSV (not necessarily within 
-    #    EnlightenSpectra/YYYY-MM-DD).  
+    # 1. It could have been loaded from ONE individual CSV (not necessarily within
+    #    EnlightenSpectra/YYYY-MM-DD).
     #    - Renaming possible, but possibly not a good idea? <-- supported
     #
     # 2. It could have been one of a SET of Measurements loaded from a big CSV
-    #    (an appended row-order or an exported column-order CSV).  
+    #    (an appended row-order or an exported column-order CSV).
     #    - Renaming considered NOT POSSIBLE.
     #
-    # 3. It could have been generated from live data and saved to one or more 
+    # 3. It could have been generated from live data and saved to one or more
     #    single-spectrum files with various extensions (csv, xls, json, png etc).
     #    - Renaming possible and apparently customer desirable <-- supported
     #
@@ -644,7 +644,7 @@ class Measurement(object):
 
         # determine what suffix we're going to use, if any
 
-        n = 0 # potential suffix 
+        n = 0 # potential suffix
         while True:
             conflict = False
             for ext in exts:
@@ -717,20 +717,20 @@ class Measurement(object):
 
     ##
     # This function is provided because legacy Dash and ENLIGHTEN saved row-
-    # ordered CSV files with very specific column headers and sequence which we 
+    # ordered CSV files with very specific column headers and sequence which we
     # don't want to casually break.
     #
     # @todo Note that temperature fields come from the underlying Reading object,
-    #       and in the case that we loaded previously-saved spectra from disk, 
-    #       we're not currently re-instantiating Reading objects (only the 
-    #       ProcessedReading, which is all that's needed for on-screen traces), 
+    #       and in the case that we loaded previously-saved spectra from disk,
+    #       we're not currently re-instantiating Reading objects (only the
+    #       ProcessedReading, which is all that's needed for on-screen traces),
     #       so currently those output a deliberately-suspicious -99.
     #
     # @todo replace if/elif with dict of lambdas
     def get_metadata(self, field):
         field = field.lower()
 
-        # allow plugins to stomp metadata 
+        # allow plugins to stomp metadata
         if self.processed_reading.plugin_metadata is not None:
             pm = self.processed_reading.plugin_metadata
             for k, v in pm.items():
@@ -754,7 +754,7 @@ class Measurement(object):
         if field == "temperature":               return self.processed_reading.reading.detector_temperature_degC if self.processed_reading.reading is not None else -99
         if field == "technique":                 return self.technique
         if field == "baseline correction algo":  return self.baseline_correction_algo
-        if field == "ccd c0":                    return 0 if len(wavecal) < 1 else wavecal[0] 
+        if field == "ccd c0":                    return 0 if len(wavecal) < 1 else wavecal[0]
         if field == "ccd c1":                    return 0 if len(wavecal) < 2 else wavecal[1]
         if field == "ccd c2":                    return 0 if len(wavecal) < 3 else wavecal[2]
         if field == "ccd c3":                    return 0 if len(wavecal) < 4 else wavecal[3]
@@ -781,7 +781,7 @@ class Measurement(object):
         if field == "wavenumber correction":     return self.settings.state.wavenumber_correction
         if field == "battery %":                 return self.processed_reading.reading.battery_percentage if self.processed_reading.reading is not None else 0
         if field == "fw version":                return self.settings.microcontroller_firmware_version
-        if field == "fpga version":              return self.settings.fpga_firmware_version 
+        if field == "fpga version":              return self.settings.fpga_firmware_version
         if field == "laser power %":             return self.processed_reading.reading.laser_power_perc if self.processed_reading.reading is not None else 0
         if field == "device id":                 return str(self.settings.device_id)
         if field == "note":                      return self.note
@@ -789,11 +789,11 @@ class Measurement(object):
         if field == "suffix":                    return self.suffix
         if field == "plugin name":               return self.plugin_name
 
-        if field == "laser power mw":            
+        if field == "laser power mw":
             if self.processed_reading.reading is not None and \
                 self.processed_reading.reading.laser_power_mW is not None and \
                 self.processed_reading.reading.laser_power_mW > 0:
-                return self.processed_reading.reading.laser_power_mW 
+                return self.processed_reading.reading.laser_power_mW
             else:
                 return ""
 
@@ -806,7 +806,7 @@ class Measurement(object):
         # if self.spec is not None:
         #     if self.settings.eeprom.multi_wavecal is not None:
         #         fields.append("Position")
-            
+
         return fields
 
     def get_all_metadata(self) -> dict:
@@ -835,19 +835,19 @@ class Measurement(object):
                     md[k] = v
 
         return md
-        
+
     # ##########################################################################
     # Excel
     # ##########################################################################
 
-    ## 
+    ##
     # Save the spectra in xls format (currently, one worksheet per x-axis)
     #
     # As with save_csv_file_by_column(), currently disregarding SaveOptions
     # selections of what x-axis and ProcessedReading fields to include, because
     # there is little benefit to removing them from individual files. We can
     # always add this later if requested.
-    # 
+    #
     # @note Only saving one column of data at this time. Make sure to
     # limit the total columns to 255 when saving multiple spectra.
     def save_excel_file(self):
@@ -983,14 +983,14 @@ class Measurement(object):
     # ##########################################################################
 
     ##
-    # Express the current Measurement as a single JSON-compatible dict.  Use this 
+    # Express the current Measurement as a single JSON-compatible dict.  Use this
     # for both save_json_file and External.Feature.
     def to_dict(self):
         pr          = self.processed_reading
         wavelengths = self.settings.wavelengths
         wavenumbers = self.settings.wavenumbers
         pixels      = len(pr.processed)
-        
+
         m = {                   # m = Measurement
             "spectrum": {},
             "metadata": self.get_all_metadata(),
@@ -1045,9 +1045,9 @@ class Measurement(object):
                                       experiment_type = SPCTechType.SPCTechRmn,
                                       log_text = log_text,
                                       )
-            spc_writer.write_spc_file(pathname, 
-                                      self.processed_reading.processed, 
-                                      numpy.asarray(self.spec.settings.wavelengths), 
+            spc_writer.write_spc_file(pathname,
+                                      self.processed_reading.processed,
+                                      numpy.asarray(self.spec.settings.wavelengths),
                                       )
         elif current_x == common.Axes.WAVENUMBERS:
             spc_writer = SPCFileWriter.SPCFileWriter(SPCFileType.TXVALS,
@@ -1056,8 +1056,8 @@ class Measurement(object):
                                       experiment_type = SPCTechType.SPCTechRmn,
                                       log_text = log_text,
                                       )
-            spc_writer.write_spc_file(pathname, 
-                                      self.processed_reading.processed, 
+            spc_writer.write_spc_file(pathname,
+                                      self.processed_reading.processed,
                                       numpy.asarray(self.spec.settings.wavenumbers),
                                       )
         elif current_x == common.Axes.PIXELS:
@@ -1065,11 +1065,11 @@ class Measurement(object):
                                       experiment_type = SPCTechType.SPCTechRmn,
                                       log_text = log_text,
                                       )
-            spc_writer.write_spc_file(pathname, 
+            spc_writer.write_spc_file(pathname,
                                       self.processed_reading.processed,
                                       y_units = SPCYType.SPCYCount,
                                       )
-        else :
+        else:
             log.error(f"current x axis doesn't match vaild values. Aborting SPC save")
             return
 
@@ -1077,9 +1077,9 @@ class Measurement(object):
     # Save the Measurement in a JSON file for simplified programmatic parsing.
     # in the next column and so on (similar layout as the Excel output).
     #
-    # As with save_excel_file(), currently disregarding SaveOptions selections 
-    # of what x-axis and ProcessedReading fields to include, because there is 
-    # little benefit to removing them from individual files. We can always add 
+    # As with save_excel_file(), currently disregarding SaveOptions selections
+    # of what x-axis and ProcessedReading fields to include, because there is
+    # little benefit to removing them from individual files. We can always add
     # this later if requested.
     def save_json_file(self, use_basename=False):
         today_dir = self.generate_today_dir()
@@ -1094,13 +1094,13 @@ class Measurement(object):
 
         log.info("saved JSON %s", pathname)
         self.add_renamable(pathname)
-    
+
     # ##########################################################################
     # Column-ordered CSV
     # ##########################################################################
 
     ##
-    # Save the Measurement in a CSV file with the x-axis in one column, spectra 
+    # Save the Measurement in a CSV file with the x-axis in one column, spectra
     # in the next column and so on (similar layout as the Excel output).
     #
     # Note that currently this is NOT writing UTF-8 / Unicode, although KIA-
@@ -1110,7 +1110,7 @@ class Measurement(object):
         wavelengths = self.settings.wavelengths
         wavenumbers = self.settings.wavenumbers
         pixels      = len(pr.raw)
-        
+
         today_dir = self.generate_today_dir()
         if use_basename:
             pathname = "%s.%s" % (self.basename, ext)
@@ -1164,16 +1164,16 @@ class Measurement(object):
 
             headers = []
             if self.save_options is not None:
-                if self.save_options.save_pixel()      : headers.append("Pixel")         
-                if self.save_options.save_wavelength() : headers.append("Wavelength")    
-                if self.save_options.save_wavenumber() : headers.append("Wavenumber")    
-                if self.save_options.save_processed()  : headers.append("Processed")     
-                if self.save_options.save_raw()        : headers.append("Raw")           
-                if self.save_options.save_dark()       : headers.append("Dark")          
-                if self.save_options.save_reference()  : headers.append("Reference")     
+                if self.save_options.save_pixel():       headers.append("Pixel")
+                if self.save_options.save_wavelength():  headers.append("Wavelength")
+                if self.save_options.save_wavenumber():  headers.append("Wavenumber")
+                if self.save_options.save_processed():   headers.append("Processed")
+                if self.save_options.save_raw():         headers.append("Raw")
+                if self.save_options.save_dark():        headers.append("Dark")
+                if self.save_options.save_reference():   headers.append("Reference")
             else:
                 headers.append("Wavenumber")
-                headers.append("Processed")     
+                headers.append("Processed")
 
             if include_header:
                 out.writerow(headers)
@@ -1191,13 +1191,13 @@ class Measurement(object):
 
                 values = []
                 if self.save_options is not None:
-                    if self.save_options.save_pixel()      : values.append(pixel)
-                    if self.save_options.save_wavelength() : values.append(formatted(2,         wavelengths,  pixel))
-                    if self.save_options.save_wavenumber() : values.append(formatted(2,         wavenumbers,  pixel))
+                    if self.save_options.save_pixel():       values.append(pixel)
+                    if self.save_options.save_wavelength():  values.append(formatted(2,         wavelengths,  pixel))
+                    if self.save_options.save_wavenumber():  values.append(formatted(2,         wavenumbers,  pixel))
 
-                    if self.save_options.save_processed(): 
+                    if self.save_options.save_processed():
                         if not cropped:
-                            values.append(formatted(precision, pr.processed, pixel)) 
+                            values.append(formatted(precision, pr.processed, pixel))
                         elif interp.enabled:
                             values.append(formatted(precision, pr.processed_vignetted, pixel))
                         elif roi.contains(pixel):
@@ -1210,14 +1210,14 @@ class Measurement(object):
                     # Note that we're always output raw/dark/ref (if selected), regardless of ROI (makes sense).
                     # I'm less sure why we don't interpolate raw/dark/ref, or how this comes out in the file if
                     # we are interpolating...
-                    if self.save_options.save_raw()        : values.append(formatted(precision, pr.raw,       pixel))
-                    if self.save_options.save_dark()       : values.append(formatted(precision, pr.dark,      pixel))
-                    if self.save_options.save_reference()  : values.append(formatted(precision, pr.reference, pixel))
+                    if self.save_options.save_raw():         values.append(formatted(precision, pr.raw,       pixel))
+                    if self.save_options.save_dark():        values.append(formatted(precision, pr.dark,      pixel))
+                    if self.save_options.save_reference():   values.append(formatted(precision, pr.reference, pixel))
                 else:
-                    # MZ: I don't remember the use-case for this.  May involve 
+                    # MZ: I don't remember the use-case for this.  May involve
                     # this class being imported and used by an outside script?
                     values.append(formatted(2, wavenumbers,  pixel))
-                    values.append(formatted(precision, pr.processed, pixel)) 
+                    values.append(formatted(precision, pr.processed, pixel))
 
                 out.writerow(values)
         log.info("saved columnar %s", pathname)
@@ -1242,27 +1242,27 @@ class Measurement(object):
     # @note left static for Measurements.export_by_row
     @staticmethod
     def generate_dash_file_header(serial_numbers):
-        header = [ "Dash Output v2.1", 
+        header = [ "Dash Output v2.1",
                    "ENLIGHTEN version: %s" % common.VERSION,
-                   "Row", 
+                   "Row",
                    "Pixel Data" ]
         header.extend(serial_numbers)
         return header
-    
+
     ##
     # Save a spectrum in CSV format with the whole spectrum on one line,
     # such that multiple acquisitions could be appended with one line
-    # per spectrum.  
+    # per spectrum.
     #
-    # This is was the ONLY supported save format in Dash and legacy ENLIGHTEN, 
-    # and still makes great sense for batch collections (it's much easier to 
+    # This is was the ONLY supported save format in Dash and legacy ENLIGHTEN,
+    # and still makes great sense for batch collections (it's much easier to
     # append lines than columns to an existing file).
     #
     # At the moment, this method is also being used to append new measurements
     # to existing files.
     #
     # Right now, we're using serial number in a new Measurement's measurement_id,
-    # hence label, hence filename.  Having serial_number in a row-ordered CSV 
+    # hence label, hence filename.  Having serial_number in a row-ordered CSV
     # which aggregates multiple spectrometers is potentially confusing, but when
     # we save the first spectrum we don't know that's the intention.
     #
@@ -1319,7 +1319,7 @@ class Measurement(object):
             else:
                 # we're creating a new file
                 verb = "saved"
-                with open(pathname, "w", newline="") as f: 
+                with open(pathname, "w", newline="") as f:
                     csv_writer = csv.writer(f)
 
                     # write the full header anytime the target does not yet exist
@@ -1344,13 +1344,13 @@ class Measurement(object):
     ##
     # For row-ordered CSVs, output any x-axis fields that have been selected.
     # Only do this if they have not yet been output for a given spectrometer.
-    # 
+    #
     # To support multiple spectrometers, we're adding the spectrometer's serial
     # number (as well as the x-axis unit) to the Notes field.
     #
-    # @note the Dash file format reprints wavecal coeffs and excitation in every 
-    #       line, so technically the recipient could regenerate pixels, 
-    #       wavelengths and wavenumbers for every spectrum anyway.  These are 
+    # @note the Dash file format reprints wavecal coeffs and excitation in every
+    #       line, so technically the recipient could regenerate pixels,
+    #       wavelengths and wavenumbers for every spectrum anyway.  These are
     #       just convenience rows.
     #
     def write_x_axis_lines(self, csv_writer):
@@ -1369,19 +1369,19 @@ class Measurement(object):
     ##
     # For row-ordered CSVs, output any ProcessedReading fields which have been
     # selected.
-    # 
-    # In column-ordered files, it's not a big deal to always store dark / 
-    # reference / raw, because they're easy to ignore if you're not using them.  
-    # However, in row-ordered files, those extra lines can be really confusing, 
-    # partly because of the "prefix columns" enforced by the file format 
-    # (repeating wavecal coeffs etc), but also because when "appending" to 
+    #
+    # In column-ordered files, it's not a big deal to always store dark /
+    # reference / raw, because they're easy to ignore if you're not using them.
+    # However, in row-ordered files, those extra lines can be really confusing,
+    # partly because of the "prefix columns" enforced by the file format
+    # (repeating wavecal coeffs etc), but also because when "appending" to
     # existing files, it becomes very hard to tell which lines are spectrum-vs-
-    # component.  So anyway, be careful not to print extra lines here that the 
+    # component.  So anyway, be careful not to print extra lines here that the
     # user didn't request.
     #
-    # Regardless, there's no "caching" these across Measurements, because 
-    # technically the user could have (and often would) take a new dark and 
-    # reference repeatedly during a session. (They're not 'reasonably persistent' 
+    # Regardless, there's no "caching" these across Measurements, because
+    # technically the user could have (and often would) take a new dark and
+    # reference repeatedly during a session. (They're not 'reasonably persistent'
     # as with the x-axis.)
     def write_processed_reading_lines(self, csv_writer):
         if self.save_options.save_processed():
@@ -1401,10 +1401,10 @@ class Measurement(object):
             csv_writer.writerow(row)
 
     ##
-    # Generate a single row of output for row-ordered CSV files.  The contents 
-    # of the generated row depend on the 'field' parameter.  
+    # Generate a single row of output for row-ordered CSV files.  The contents
+    # of the generated row depend on the 'field' parameter.
     #
-    # Metadata is only populated for x-axis fields and the FIRST ProcessedReading 
+    # Metadata is only populated for x-axis fields and the FIRST ProcessedReading
     # array.
     def build_row(self, field):
         field = field.lower()
@@ -1438,7 +1438,7 @@ class Measurement(object):
 
         if a is None:
             return None
-            
+
         row = []
 
         # don't repeat metadata for spectrum components
@@ -1461,17 +1461,17 @@ class Measurement(object):
 
         return row
 
-    ## Called (by way of ThumbnailWidget -> KnowItAll.Feature -> Measurements) 
+    ## Called (by way of ThumbnailWidget -> KnowItAll.Feature -> Measurements)
     # when KnowItAll has generated a KnowItAll.DeclaredMatch for this Measurement.
     def id_callback(self, declared_match):
         # store the match
         self.declared_match = declared_match
-        
+
         # re-save files using current SaveOptions (will store new label, overwriting old files with old name)
         # (these will definitely be in TODAY directory, regardless of where they were loaded from)
         self.save()
 
-        # close-out the pending button click on the thumbnail (basically just 
+        # close-out the pending button click on the thumbnail (basically just
         # turns the button back from red to gray)
         if self.thumbnail_widget is not None:
             self.thumbnail_widget.id_complete_callback()
@@ -1493,15 +1493,15 @@ class Measurement(object):
             a = pr.processed
         else:
             return False
-        
+
         return a is not None and len(a) > 0
 
-    ## 
+    ##
     # Passed a SpectrometerSettings object (containing wavelengths, wavenumbers
     # etc), return a copy of this Measurement's ProcessedReading which has been
-    # interpolated to the passed x-axis.  
+    # interpolated to the passed x-axis.
     #
-    # Interpolate on wavelength if available, otherwise wavenumbers, otherwise 
+    # Interpolate on wavelength if available, otherwise wavenumbers, otherwise
     # just copy the uninterpolated pixel data.
     #
     # Who calls this?
@@ -1522,11 +1522,11 @@ class Measurement(object):
            new_x =  new_settings.wavenumbers
         else:
             log.error("no interpolation possible")
-            return 
+            return
 
-        log.debug("interpolating from (%.2f, %.2f) to (%.2f, %.2f)", 
+        log.debug("interpolating from (%.2f, %.2f) to (%.2f, %.2f)",
             old_x[0], old_x[-1], new_x[0], new_x[-1]);
-        
+
         if pr.raw is not None and len(pr.raw) > 0:
             pr.raw = numpy.interp(new_x, old_x, pr.raw)
 
@@ -1538,5 +1538,5 @@ class Measurement(object):
 
         if pr.processed is not None and len(pr.processed) > 0:
             pr.processed = numpy.interp(new_x, old_x, pr.processed)
-        
+
         log.debug("interpolation complete")

--- a/enlighten/measurement/Measurement.py
+++ b/enlighten/measurement/Measurement.py
@@ -276,7 +276,6 @@ class Measurement(object):
             save_options        = None,
             settings            = None,
             source_pathname     = None,
-            technique           = None,
             timestamp           = None,
             spec                = None,
             measurement         = None,

--- a/enlighten/measurement/MeasurementFactory.py
+++ b/enlighten/measurement/MeasurementFactory.py
@@ -85,14 +85,13 @@ class MeasurementFactory(object):
 
     ## Create a Measurement from a Spectrometer, using its most-recent 
     #  ProcessedReading.
-    def create_from_spectrometer(self, spec, is_collapsed, view=None, generate_thumbnail=True, save=True):
+    def create_from_spectrometer(self, spec, is_collapsed, generate_thumbnail=True, save=True):
         log.debug("creating Measurement from spec %s", spec.label)
 
         # instantiate the Measurement
         measurement = Measurement(
             save_options = self.save_options,
             spec         = spec,
-            view         = view,
             measurements = self.measurements)
         log.debug("created Measurement %s from reading %d", measurement.measurement_id, measurement.processed_reading.reading.session_count)
 

--- a/enlighten/measurement/Measurements.py
+++ b/enlighten/measurement/Measurements.py
@@ -760,7 +760,7 @@ class Measurements(object):
             if a is not None and pixel < len(a):
                 value = a[pixel]
             else:
-                return ""
+                return "NA"
 
             # Override default precision (which was based on whether a "reference" column
             # is being exported) with this indication of whether a reference component was
@@ -793,10 +793,8 @@ class Measurements(object):
                     log.error("failed export due to interpolation error")
                 if m.roi_active:
                     roi = m.settings.eeprom.get_horizontal_roi()
-                    if roi.start < min_roi_start:
-                        min_roi_start = int(roi.start)
-                    if roi.end > max_roi_end:
-                        max_roi_end = int(roi.end)
+                    min_roi_start = min(min_roi_start, int(roi.start))
+                    max_roi_end = max(max_roi_end, int(roi.end))
                 m.ipr = ipr
 
             if max_roi_end != float("-inf") and min_roi_start != float("inf"):
@@ -846,7 +844,7 @@ class Measurements(object):
                             if pixel < m.settings.pixels():
                                 row.append(get_pr_header_value(m, header, pixel))
                             else:
-                                row.extend(BLANK)
+                                row.extend("NA")
                 else:
                     for m in self.measurements:
                         if pixel < m.settings.pixels():

--- a/enlighten/measurement/Measurements.py
+++ b/enlighten/measurement/Measurements.py
@@ -230,7 +230,7 @@ class Measurements(object):
     ## 
     # Use the MeasurementFactory to instantiate a new Measurement, including
     # ThumbnailWidget, from the given spectrometer's latest ProcessedReading.
-    def create_from_spectrometer(self, spec, view=None):
+    def create_from_spectrometer(self, spec):
         if spec is None or spec.app_state.processed_reading is None:
             return
 
@@ -240,8 +240,7 @@ class Measurements(object):
         # using the current "collapsed" state
         measurement = self.factory.create_from_spectrometer(
             spec = spec, 
-            is_collapsed = self.is_collapsed,
-            view = view)
+            is_collapsed = self.is_collapsed)
 
         self.add(measurement)
 
@@ -828,10 +827,11 @@ class Measurements(object):
             #####################################################################           
 
             for pixel in range(max_pixels):
-                if spectrometer_count == 1:
-                    roi = settingss[0].eeprom.get_horizontal_roi()
-                    if roi is not None and not roi.contains(pixel) and self.vignette_roi.enabled:
-                        continue
+                # MZ: always export all rows
+                # if spectrometer_count == 1:
+                #     roi = settingss[0].eeprom.get_horizontal_roi()
+                #     if roi is not None and not roi.contains(pixel) and self.vignette_roi.enabled:
+                #         continue
 
                 row = []
                 for settings in settingss:

--- a/enlighten/measurement/Measurements.py
+++ b/enlighten/measurement/Measurements.py
@@ -361,7 +361,10 @@ class Measurements(object):
 
         if filename is None:
             now = datetime.datetime.now()
-            default_filename = "Session-" + now.strftime("%Y%m%d-%H%M%S")
+
+            default_filename = f"{self.save_options.prefix()}-" if self.save_options.has_prefix() else "Session-"
+            default_filename += now.strftime("%Y%m%d-%H%M%S")
+            default_filename += f"-{self.save_options.suffix()}" if self.save_options.has_suffix() else ""
 
             # prompt the user to override the default filename
             # @todo give Controller.form to GUI, add gui.promptString()

--- a/enlighten/measurement/SaveOptions.py
+++ b/enlighten/measurement/SaveOptions.py
@@ -221,8 +221,10 @@ class SaveOptions():
         self.cb_dark.setEnabled(True)
         self.cb_reference.setEnabled(True)
 
-        # dependent on excitation
-        self.cb_wavenumber.setEnabled(spec.has_excitation() if spec else False)
+        # MZ: always enable wavenumbers, as we might want to load/export Raman 
+        #     data even when not connected to a Raman spectrometer
+        # self.cb_wavenumber.setEnabled(spec.has_excitation() if spec else False)
+        self.cb_wavenumber.setEnabled(True)
 
         ########################################################################
         # Reset append_pathname when disabled or prefix/suffix changes

--- a/enlighten/measurement/SaveOptions.py
+++ b/enlighten/measurement/SaveOptions.py
@@ -308,6 +308,9 @@ class SaveOptions():
     def save_wavenumber         (self): return self.cb_wavenumber.isChecked() and self.cb_wavenumber.isEnabled() or self.save_with_wavenumber
     def suffix                  (self): return self.le_suffix.text().strip()
     def save_processed          (self): return True
+    def has_prefix              (self): return len(self.prefix()) > 0
+    def has_suffix              (self): return len(self.suffix()) > 0
+    def has_note                (self): return len(self.note()) > 0
 
     # ##########################################################################
     # Methods

--- a/enlighten/parser/ColumnFileParser.py
+++ b/enlighten/parser/ColumnFileParser.py
@@ -45,7 +45,7 @@ class ColumnFileParser(object):
 
     def parse(self) -> Measurement:
         # read through the input file by line, loading data locally
-        self.csv_loader.load_data()
+        self.csv_loader.load_data(scalar_metadata=True)
 
         # put loaded data into where it goes in ENLIGHTEN datatypes
         self.post_process_metadata()
@@ -61,17 +61,16 @@ class ColumnFileParser(object):
             processed_reading = self.processed_reading,
             save_options      = self.save_options)
 
-        # log.info(f"\nAfter creating measurement the wave coeffs are {m.settings.eeprom.wavelength_coeffs}\n")
-
-        # note that label often won't be what the user expected, because they
-        # may have editted it in the Capture Bar AFTER the file was created,
-        # and currently we don't re-save the file when the label is changed.
-        # (nor do we rename the file with the label, as that would rule-out
-        # many characters and syntax in the label)
         if "Label" in self.metadata:
             m.label = self.metadata["Label"]
         else:
+            # this was probably for an external script
             m.label = os.path.splitext(os.path.basename(self.pathname))[0]
+
+        # attributes of Measurement itself
+        for k in ["Note", "Prefix", "Suffix"]:
+            if k in self.metadata:
+                setattr(m, k.lower(), self.metadata[k])
 
         # this parser only loads a single measurement, so the file is renamable
         m.add_renamable(self.pathname)
@@ -83,29 +82,19 @@ class ColumnFileParser(object):
     # ##########################################################################
 
     def get_safe_float(self, field):
-        field = field.lower()
         if field not in self.metadata or self.metadata[field] is None:
             return 0
 
         v = self.metadata[field]
-        if type(v) is list:
-            if len(v) == 1:
-                s = v[0]
-            else:
-                s = str(v)
-        else:
-            s = str(v)
-
-        s = s.strip()
-        if len(s) == 0:
+        if len(v.strip()) == 0:
             return 0
 
         try:
-            value = float(s)
+            value = float(v)
             log.debug(f"parsed float {field} as {value}")
             return value
         except:
-            log.error(f"failed to convert {field} to float: {s}")
+            log.error(f"failed to convert {field} to float: {v}")
             return 0
 
     def parse_timestamp(self, ts):
@@ -197,6 +186,8 @@ class ColumnFileParser(object):
             eeprom.active_pixels_horizontal = len(self.processed_reading.processed)
         log.debug("active_pixels_horizontal = %d", eeprom.active_pixels_horizontal)
 
+        # fields where name changed in different versions / generators
+
         # serial number
         for key in ["Serial Number", "Serial"]:
             if key in metadata:
@@ -218,6 +209,7 @@ class ColumnFileParser(object):
                 state.integration_time_ms = int(self.get_safe_float(key))
 
         eeprom.model                      = metadata.get("Model")
+        eeprom.detector                   = metadata.get("Detector")
         eeprom.detector_offset            = int(self.get_safe_float("CCD Offset"))
         eeprom.detector_gain              = self.get_safe_float("CCD Gain")
         eeprom.excitation_nm_float        = self.get_safe_float("Laser Wavelength")
@@ -227,6 +219,9 @@ class ColumnFileParser(object):
                                           
         state.laser_enabled               = metadata.get("Laser Enable", "false").lower().strip() == "true"
         state.scans_to_average            = int(self.get_safe_float("Scan Averaging"))
+
+        self.settings.microcontroller_firmware_version = metadata.get("FW Version")
+        self.settings.fpga_firmware_version = metadata.get("FPGA Version")
 
         reading.laser_temperature_degC    = self.get_safe_float("Laser Temperature")
 

--- a/enlighten/parser/ColumnFileParser.py
+++ b/enlighten/parser/ColumnFileParser.py
@@ -83,10 +83,20 @@ class ColumnFileParser(object):
     # ##########################################################################
 
     def get_safe_float(self, field):
+        field = field.lower()
         if field not in self.metadata or self.metadata[field] is None:
             return 0
 
-        s = self.metadata[field].strip()
+        v = self.metadata[field]
+        if type(v) is list:
+            if len(v) == 1:
+                s = v[0]
+            else:
+                s = str(v)
+        else:
+            s = str(v)
+
+        s = s.strip()
         if len(s) == 0:
             return 0
 
@@ -248,7 +258,6 @@ class ColumnFileParser(object):
             if coeffs is not None:
                 eeprom.wavelength_coeffs = coeffs
         elif coeffs is not None:
-            log.debug("loaded metadata wavecal coeffs")
             eeprom.wavelength_coeffs = coeffs
 
             # this will also render wavenumbers if possible
@@ -272,9 +281,11 @@ class ColumnFileParser(object):
             c1 = self.get_safe_float("CCD C1")
             c2 = self.get_safe_float("CCD C2")
             c3 = self.get_safe_float("CCD C3")
+            c4 = self.get_safe_float("CCD C4")
             if c0 > 0:
-                return [ c0, c1, c2, c3 ]
+                return [ c0, c1, c2, c3, c4 ]
         except Exception as e:
+            log.debug("get_wavecal_coeffs_from_metadata: ignoring {e}")
             return
 
     def get_header_col(self, field):

--- a/enlighten/parser/ColumnFileParser.py
+++ b/enlighten/parser/ColumnFileParser.py
@@ -161,6 +161,11 @@ class ColumnFileParser(object):
         In cases where we're looking for different field spellings, those may 
         have been added to better support other application file formats
         (such as RamanSpecCal).
+
+        Defects:
+        
+        - we're not currently instantiating a SpectrometerApplicationState so have nowhere to store technique_name
+        - we're not loading DeviceID (could)
         """
         metadata = self.metadata
 

--- a/enlighten/parser/ExportFileParser.py
+++ b/enlighten/parser/ExportFileParser.py
@@ -194,8 +194,12 @@ class ExportFileParser(object):
                 settings          = em.settings,
                 processed_reading = em.processed_reading,
                 save_options      = self.save_options)
-            if "Label" in em.metadata:
-                m.label = em.metadata["Label"]
+
+            # additional Measurement attributes
+            for k in ["Label", "Prefix", "Suffix", "Note"]: 
+                if k in em.metadata:
+                    setattr(m, k.lower(), em.metadata[k])
+
             self.measurements.append(m)
 
         # if only a single Measurement was found within the export (rare),

--- a/enlighten/parser/ExportFileParser.py
+++ b/enlighten/parser/ExportFileParser.py
@@ -5,6 +5,7 @@ import re
 
 from enlighten.measurement.Measurement import Measurement
 
+from wasatch.Reading import Reading
 from wasatch.ProcessedReading import ProcessedReading
 from wasatch.SpectrometerSettings import SpectrometerSettings
 
@@ -16,13 +17,12 @@ class ExportedMeasurement(object):
     
     @todo this can probably be generalized and re-used for ColumnFileParser at 
           least, and likely DashFileParser as well.
-    @todo populate temperature and laser temperature
     """
     def __init__(self):
         self.headers = []
         self.header_count = 1
         self.metadata = {}
-        self.processed_reading = ProcessedReading()
+        self.processed_reading = ProcessedReading(reading=Reading())
 
 class ExportFileParser(object):
     """
@@ -47,6 +47,8 @@ class ExportFileParser(object):
     
     A unit-test of sorts for this class can be found in 
     enlighten/scripts/split-spectra.py.
+
+    @warning this does not currently work with "collated" exports.
     """ 
     def __init__(self, pathname, save_options, encoding="utf-8"):
         self.pathname = pathname
@@ -82,7 +84,7 @@ class ExportFileParser(object):
     # Private methods
     # ##########################################################################
 
-    def post_process_metadata(self, em):
+    def post_process_metadata(self, em: ExportedMeasurement):
         """ @see ColumnFileParser.post_process_metadata """
         if self.format == 1:
             metadata = self.global_metadata
@@ -136,7 +138,6 @@ class ExportFileParser(object):
 
         def get_string(key):
             return metadata.get(key, "")
-            
 
         # TODO: add get_metadata with try-except
         eeprom.wavelength_coeffs        = []
@@ -144,12 +145,14 @@ class ExportFileParser(object):
         eeprom.wavelength_coeffs.append(get_float("CCD C1"))
         eeprom.wavelength_coeffs.append(get_float("CCD C2"))
         eeprom.wavelength_coeffs.append(get_float("CCD C3"))
-        eeprom.serial_number            = metadata["Serial Number"] if "Serial Number" in metadata else "unknown"
-        eeprom.model                    = metadata["Model"] if "Model" in metadata else "unknown"
+        eeprom.wavelength_coeffs.append(get_float("CCD C4"))
+        eeprom.serial_number            = metadata.get("Serial Number")
+        eeprom.model                    = metadata.get("Model")
+        eeprom.detector                 = metadata.get("Detector")
         eeprom.detector_offset          = get_int("CCD Offset")
         eeprom.detector_gain            = get_float("CCD Gain")
-        eeprom.excitation_nm            = get_float("Laser Wavelength")
-        eeprom.excitation               = eeprom.excitation_nm
+        eeprom.excitation_nm_float      = get_float("Laser Wavelength")
+        eeprom.excitation_nm            = eeprom.excitation_nm
         eeprom.active_pixels_horizontal = get_int("Pixel Count")
         eeprom.roi_horizontal_start     = get_int("ROI Pixel Start")
         eeprom.roi_horizontal_end       = get_int("ROI Pixel End")
@@ -158,6 +161,12 @@ class ExportFileParser(object):
         state.laser_enabled             = get_string("Laser Enable").lower().strip() == "true"
         state.scans_to_average          = get_int("Scan Averaging") 
         state.boxcar_half_width         = get_int("Boxcar")
+
+        em.settings.microcontroller_firmware_version = metadata.get("FW Version")
+        em.settings.fpga_firmware_version = metadata.get("FPGA Version")
+
+        em.processed_reading.reading.detector_temperature_degC = get_float("Temperature")
+        em.processed_reading.reading.laser_temperature_degC = get_float("Laser Temperature")
 
         if "Laser Power" in metadata:
             state.laser_power_perc      = get_float("Laser Power")
@@ -402,7 +411,6 @@ class ExportFileParser(object):
             for i in range(em.header_count):
                 try:
                     header = em.headers[i].lower()
-                    log.debug(f"for em {em}, trying to process header {header}")
                 except:
                     continue
 
@@ -413,6 +421,10 @@ class ExportFileParser(object):
                     # skip nulls
                     if len(value) == 0:
                         continue
+
+                    # MZ: honestly not sure how to handle these
+                    if value == "NA":
+                        value = 0
 
                     if   header == "processed": array = em.processed_reading.processed
                     elif header == "raw":       array = em.processed_reading.raw      

--- a/enlighten/scope/LaserControlFeature.py
+++ b/enlighten/scope/LaserControlFeature.py
@@ -497,8 +497,8 @@ class LaserControlFeature:
         box.setWindowTitle(label)
         box.setText("Are you sure you wish to disable the laser watchdog? " +
             "Running the laser without watchdog could damage the instrument, risk human injury " +
-            "and void your warranty.")
-        box.setInformativeText("Disabling watchdog voids warranty.")
+            "and may void your warranty.")
+        box.setInformativeText("Disabling watchdog may void warranty.")
         box.setStandardButtons(QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.Cancel)
 
         retval = box.exec_()

--- a/enlighten/spectra_processes/RamanIntensityCorrection.py
+++ b/enlighten/spectra_processes/RamanIntensityCorrection.py
@@ -132,7 +132,10 @@ class RamanIntensityCorrection(object):
             # probably a faster Numpy way to do this
             for i in range(len(pr.processed_vignetted)):
                 pr.processed_vignetted[i] *= factors[i + roi.start]
-        else:    
+        else:
+            # note that this scales the entire spectrum, within and without the 
+            # ROI, even though the factors are really only applicable/sensible/
+            # defined within the ROI
             pr.processed *= factors
 
         pr.raman_intensity_corrected = True


### PR DESCRIPTION
The use-case is to launch ENLIGHTEN, use "Load" to load several previously-saved single-Measurement CSV files, then clicking "Export".

Digging into the code, it looks like at some point ColumnFileParser started storing metadata internally as a list (presumably for use when loading multi-Measurement export files).  This broke single-file load.  Also there seemed to be confusion on field capitalization, and an assumption that metadata would always include wavecal coeffs.

The changes were tested by successfully loading several spectra collected over a span of days and re-exporting them.