### PR TITLE
Expand template macros in export filenames

### DIFF
--- a/README_CHANGELOG.md
+++ b/README_CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # 4.0 GUI Refactoring
 
+- 2023-??-?? 4.0.13
+    - enlighten.ini allows % 
+    - template macro fixes
+        - work in export filenames
+        - support Reading attributes
+        - improved floating-point precision
 - 2023-06-14 4.0.12
     - persistence
         - fixed Configuration defaults

--- a/enlighten/file_io/Configuration.py
+++ b/enlighten/file_io/Configuration.py
@@ -174,7 +174,7 @@ class Configuration(object):
 
     def parse(self):
         """ Load as ConfigParser object. """
-        self.config = configparser.ConfigParser()
+        self.config = configparser.ConfigParser(interpolation=None)
         self.config.optionxform = str
         try:
             self.config.read(self.pathname)

--- a/enlighten/file_io/Configuration.py
+++ b/enlighten/file_io/Configuration.py
@@ -395,6 +395,8 @@ class Configuration(object):
             "format_excel": False,
             "format_json":  False,
 
+            "label_template": "{time} {serial_number}",
+
             "prefix":       "enlighten",
             "suffix":       "",
             "note":         "",

--- a/enlighten/measurement/Measurement.py
+++ b/enlighten/measurement/Measurement.py
@@ -316,9 +316,9 @@ class Measurement(object):
             self.baseline_correction_algo = spec.app_state.baseline_correction_algo
 
             # do these AFTER we have a processed_reading
-            self.note = self.generate_format_field("note")
-            self.prefix = self.generate_format_field("prefix")
-            self.suffix = self.generate_format_field("suffix")
+            self.note   = self.expand_template(self.save_options.note())
+            self.prefix = self.expand_template(self.save_options.prefix())
+            self.suffix = self.expand_template(self.save_options.suffix())
 
         elif source_pathname:
             log.debug("instantiating from source pathname %s", source_pathname)
@@ -421,63 +421,54 @@ class Measurement(object):
 
         self.basename = self.measurement_id # use this as the original base filename
 
-        # the ID is too long for on-screen display, so shorten it
+        # we don't use measurement_id for on-screen display; unless a label has 
+        # already been provided, generate one using the configured template
         if self.label is None:
-            self.label = "%s %s" % (self.timestamp.strftime("%H:%M:%S"), self.settings.eeprom.serial_number)
-
-            self.label = self.generate_format_field("label")
+            self.label = self.expand_template(self.save_options.label_template())
 
             # append optional suffix
-            # log.debug("checking for label_suffix")
             if self.measurements is not None and \
                     self.measurements.factory is not None and \
                     self.measurements.factory.label_suffix is not None:
-                self.label += " %s" % self.measurements.factory.label_suffix
-                # log.debug("applying label_suffix (%s): %s", self.measurements.factory.label_suffix, self.label)
+                self.label += f" {self.measurements.factory.label_suffix}"
 
                 # this complicates saving from multiple spectrometers
                 # during batch collection
                 self.measurements.factory.label_suffix = None
 
-    def generate_format_field(self, field = None):
-        if field == None:
-            return ''
-        try:
-            fields = {
-                "label": self.save_options.label_template,
-                "prefix": self.save_options.prefix,
-                "suffix": self.save_options.suffix,
-                "note": self.save_options.note,
-                }
-            label = fields[field]()
-        except:
-            if field == "label":
-                label = "{time}"
-            else:
-                label == ""
-        log.debug(f"generate_format_field: starting with template {label}")
+    def expand_template(self, template):
+        """
+        Some GUI text fields allow the user to enter strings containining "macro 
+        templates" which are dynamically expanded and evaluated at runtime.
 
+        Macros look like "{field_name}", where field_name can be any object 
+        attribute in wasatch.EEPROM, wasatch.SpectrometerState, or Measurement
+        metadata (any field supported by Measurement.get_metadata). As a 
+        convenience some hardcoded macros are also supported, such as {time}.
+        """
+        log.debug(f"expand_template: starting with template {template}")
         while True:
-            m = re.search(r"{([a-z0-9_]+)}", label, re.IGNORECASE)
+            m = re.search(r"{([a-z0-9_]+)}", template, re.IGNORECASE)
             if m is None:
-                return label
+                return template
 
-            code = m.group(1)
+            macro = m.group(1)
             value = None
-            if code == "time":
+
+            if macro == "time":
                 value = self.timestamp.strftime("%H:%M:%S")
-            elif hasattr(self.settings.eeprom, code):
-                value = getattr(self.settings.eeprom, code)
-            elif hasattr(self.settings.state, code):
-                value = getattr(self.settings.state, code)
+            elif hasattr(self.settings.eeprom, macro):
+                value = getattr(self.settings.eeprom, macro)
+            elif hasattr(self.settings.state, macro):
+                value = getattr(self.settings.state, macro)
             else:
-                value = self.get_metadata(code)
+                value = self.get_metadata(macro)
 
             if isinstance(value, float):
                 value = f"{value:.3f}"
 
-            label = label.replace("{%s}" % code, str(value))
-            log.debug(f"generate_format_field: {code} -> {value} ({field} now {label})")
+            template = template.replace("{%s}" % macro, str(value))
+            log.debug(f"expand_template: {macro} -> {value} (now {template})")
 
     def generate_basename(self):
         if self.save_options is None:

--- a/enlighten/measurement/Measurement.py
+++ b/enlighten/measurement/Measurement.py
@@ -457,6 +457,8 @@ class Measurement(object):
 
             if macro == "time":
                 value = self.timestamp.strftime("%H:%M:%S")
+            elif self.processed_reading and self.processed_reading.reading and hasattr(self.processed_reading.reading, macro):
+                value = getattr(self.processed_reading.reading, macro)
             elif hasattr(self.settings.eeprom, macro):
                 value = getattr(self.settings.eeprom, macro)
             elif hasattr(self.settings.state, macro):
@@ -465,7 +467,13 @@ class Measurement(object):
                 value = self.get_metadata(macro)
 
             if isinstance(value, float):
-                value = f"{value:.3f}"
+                if macro in ['gain_db']:
+                    fmt = "{0:.1f}"
+                elif 'excitation' in macro:
+                    fmt = "{0:.3f}"
+                else
+                    fmt = "{0:.2f}"
+                value = fmt.format(value)
 
             template = template.replace("{%s}" % macro, str(value))
             log.debug(f"expand_template: {macro} -> {value} (now {template})")

--- a/enlighten/measurement/Measurements.py
+++ b/enlighten/measurement/Measurements.py
@@ -365,6 +365,8 @@ class Measurements(object):
             default_filename += now.strftime("%Y%m%d-%H%M%S")
             default_filename += f"-{self.save_options.suffix()}" if self.save_options.has_suffix() else ""
 
+            default_filename = self.measurements[-1].expand_template(default_filename)
+
             # prompt the user to override the default filename
             # @todo give Controller.form to GUI, add gui.promptString()
             (filename, ok) = QtWidgets.QInputDialog().getText(


### PR DESCRIPTION
The immediate bug this was intended to fix was if the currently configured Prefix and Suffix fields (in SaveOptions) happen to themselves contain macro templates (e.g. {serial_number}), then those templates should be expanded when the prefix and suffix are applied to export filenames (exactly as they already were when applied to Measurement filenames).

When looking at this code there is clearly much room for improvement (it's a bit of a cop-out to simply use the last-saved Measurement as the"definitive" source of macro evaluation for the entire export), but this meets the immediate need and is a step forward.