### PR TITLE
added virtspec to bootstrap

### DIFF
--- a/README_VIRTSPEC.md
+++ b/README_VIRTSPEC.md
@@ -1,0 +1,46 @@
+## Introduction
+
+"Virtspec" is a short-name for [PyUsb-virtSpec](https://github.com/WasatchPhotonics/pyusb-virtSpec). 
+It is a project, separate from Enlighten, that provides an imaginary spectrometer connected via USB.
+It provides a bare-bones implementation of a spectrometer, including EEPROM and spectra, that is suitable for testing plugins or Measurements, for example.
+
+It is not to be confused with virtSpec-GUI or MockDevice. Some old commits/branches/code may be talking about virtual spectrometers, but anything before 2023 
+is not related to PyUSB-virtSpec. Likewise, anything virtspec 2023+ _is_ about PyUsb-virtSpec. Previous work on this topic should be deprecated due to timing and the 
+fact that previous attempts at virtual devices involved modifying our own source programs. That added to architectural bloat and impeded both virtual and real 
+device testing.
+
+This module is intended for in-house testing, and while it is possible to produce a build containing it, I don't recommend that without careful consideration
+and likely some additional engineering. When the virtual spectrometer is enabled, real ones are ignored (see pyusb-virtSpec's README for work-around). 
+Obviously no real spectrometer needs to be connected in order to use the real one--the purpose is easy testing on the go.
+
+The following is a guide on how to get started. It's mostly just cloning the repository in a folder next to Enlighten, but there's also a hint for using
+virtSpec on an old (pre-2023) version of Enlighten.
+
+## Local "Installation"
+    
+    pwd # path/to/Enlighten
+    cd ..
+    git clone git@github.com:WasatchPhotonics/pyusb-virtSpec.git
+
+## Usage
+
+Now "virtspec" can be added to the end of any bootstrap command.
+
+```
+scripts\bootstrap activate virtspec
+```
+
+To go back to using a real one:
+
+```
+scripts\bootstrap activate
+```
+
+## Note
+
+Because of how it's kept outside of the Enlighten codebase, pyusb-virtspec will work with (probably) any version of Enlighten. To do so easily, you may want to patch the build script to your working tree:
+
+```
+git checkout <past version>
+git checkout main scripts/bootstrap.bat
+```

--- a/scripts/bootstrap.bat
+++ b/scripts/bootstrap.bat
@@ -15,10 +15,16 @@ set "pyinstaller=0"
 set "innosetup=0"
 set "runtests=0"
 
+set "virtspec=0"
+
 REM Convoluted but safe way to generate an audible bell from a .bat
 REM without inserting control characters which confuse unix2dos etc.
 REM https://stackoverflow.com/a/64515648
 set "RING_BELL=echo x|choice /n 2>nul"
+
+if "%2" == "virtspec" (
+    set "virtspec=1"
+)
 
 if "%1" == "activate" (
     goto args_parsed
@@ -82,6 +88,9 @@ if "%1" == "custom" (
 echo === USAGE ===
 echo $ scripts\bootstrap activate
 echo Do not perform any major actions. Prepare environment variables and conda for using Enlighten.
+echo.
+echo $ scripts\bootstrap activate virtspec
+echo Prepare environment variables and conda for using Enlighten with a virtual spectrometer. (use bootstrap activate to revert to normal)
 echo.
 echo $ scripts\bootstrap pyinstaller
 echo regenerate Qt views and run pyinstaller (to create standalone exe)
@@ -300,6 +309,19 @@ if "%install_python_deps%" == "1" (
     echo.
     pip install pyinstaller==4.5.1
     if %errorlevel% neq 0 goto script_failure
+)
+
+if "%virtspec%" == "1" (
+    echo.
+    echo %date% %time% ======================================================
+    echo %date% %time% * Appending PyUSB Virtual Spectrometer to PATH *
+    echo %date% %time% ======================================================
+    echo.
+    set PYTHONPATH=..\pyusb-virtSpec;%PYTHONPATH%
+    pip uninstall pyusb
+)
+if "%virtspec%" == "0" (
+    pip install pyusb==1.2.1
 )
 
 if "%log_conf_pkg%" == "1" (


### PR DESCRIPTION
## Local "Installation"
    
    pwd # path/to/Enlighten
    cd ..
    git clone git@github.com:WasatchPhotonics/pyusb-virtSpec.git

## Usage

Now "virtspec" can be added to the end of any bootstrap command.

```
scripts\bootstrap activate virtspec
```

To go back to using a real one:

```
scripts\bootstrap activate
```

## Note

Because of how it's kept outside of the Enlighten codebase, pyusb-virtspec will work with (probably) any version of Enlighten. To do so easily, you may want to patch the build script to your working tree:

```
git checkout <past version>
git checkout main scripts/bootstrap.bat
```

This process was helpful when I did a git bisect for the last bug fix.
