### PR TITLE
Template format precision

### DIFF
--- a/README_CHANGELOG.md
+++ b/README_CHANGELOG.md
@@ -11,7 +11,7 @@
             - added filename template
             - macros now work in export filename components
             - support Reading attributes
-            - improved floating-point precision
+            - user-configurable floating-point precision
             - added date/time components ({YYYY}, {hh} etc)
             - added file_timestamp, integration_time_sec macros
     - persistence

--- a/enlighten/measurement/Measurement.py
+++ b/enlighten/measurement/Measurement.py
@@ -510,7 +510,11 @@ class Measurement(object):
                         fmt = "{0:.3f}"
                     else:
                         fmt = "{0:.2f}"
-                value = fmt.format(value)
+                try:
+                    value = fmt.format(value)
+                except ValueError:
+                    log.error(f"unable to format value {value} as {fmt}", exc_info=1)
+                    value = macro
 
             template = template.replace("{%s}" % macro, str(value))
             log.debug(f"expand_template: {macro} -> {value} (now {template})")

--- a/enlighten/measurement/Measurement.py
+++ b/enlighten/measurement/Measurement.py
@@ -465,8 +465,9 @@ class Measurement(object):
             if m is None:
                 return template
 
+            orig = m.group(0)
             macro = m.group(1)
-            fmt = m.group(1)[1:] if m.group(1) else None
+            fmt = "{0:%s}" % m.group(2)[1:] if m.group(2) else None
             value = None
 
             ####################################################################
@@ -516,8 +517,8 @@ class Measurement(object):
                     log.error(f"unable to format value {value} as {fmt}", exc_info=1)
                     value = macro
 
-            template = template.replace("{%s}" % macro, str(value))
-            log.debug(f"expand_template: {macro} -> {value} (now {template})")
+            template = template.replace(orig, str(value))
+            log.debug(f"expand_template: {orig} -> {value} (now {template})")
 
     # Note that this wraps the prefix and suffix around the expanded template.
     # Prefix and Suffix are not retained in manually-renamed measurements (ctrl-E).

--- a/scripts/embed_stylesheet.py
+++ b/scripts/embed_stylesheet.py
@@ -45,6 +45,8 @@ element.text = css
 # save updated .ui
 try:
     tree.write(ui_path, encoding="UTF-8")
+    with open(ui_path, "a", encoding="UTF-8") as f:
+        f.write("\n")
 except:
     error("Unable to write %s" % ui_path)
 


### PR DESCRIPTION
I know we need to refactor this to manage complexity, but I realized this one small tweak would probably address a range of user requests.

- accepts templates of the form {gain_db:0.1f}
- everything after the colon is used directly as the format code
- only applied to "known float" values