### PR TITLE
Do not show stale scan average counts

### DIFF
--- a/enlighten/spectra_processes/ScanAveragingFeature.py
+++ b/enlighten/spectra_processes/ScanAveragingFeature.py
@@ -81,7 +81,11 @@ class ScanAveragingFeature(object):
 
         # update label
         count = max(1, min(count, spec.settings.state.scans_to_average))
-        self.label.setVisible(True)
+
+        # patch #179
+        if count == 1:
+            self.label.setVisible(True)
+
         self.label.setText("Collected %d of %d" % (count, spec.settings.state.scans_to_average))
 
     def up(self):


### PR DESCRIPTION
When you pause and resume at high integration times scan average looked like it was stuck on the last index.

For example at int=5000ms, "Collected 12 of 38" followed by `[ Pause ]` and then `[Step & Save]` would show "Collected 12 of 38" for up to 5000ms until the next reading came in. Then it would correctly change to "Collected 1 of 38".

Close #179