### PR TITLE
Prepare for small release 4.0.14

### DIFF
--- a/README_CHANGELOG.md
+++ b/README_CHANGELOG.md
@@ -2,7 +2,10 @@
 
 # 4.0 GUI Refactoring
 
-- 2023-??-?? 4.0.13
+- 2023-07-19 4.0.14
+    - extend boxcar to left and right edges of spectra
+    - clear scan average count upon reset
+- 2023-07-07 4.0.13
     - spectrometer control
         - support selectable mW/PWM for ILC and Expert Mode
     - data management


### PR DESCRIPTION
Preparing for a small release containing a fix that a customer has been wanting for a while (scan averages).

---
(details) Technically this is only a visual fix: not displaying a stale value in a label. But this made it look like the counter was going to continue to count up, which causes the user to reasonably avoid using the pause/continue feature altogether. It also gave the impression that the new batch might be 'corrupted' with an errant frame from the last batch making it into the average. 

Not only does it not _look_ that way anymore, but I've checked and confirmed that upon reset no old frames will actually make it into a new scan average, even before this change.

---
Upon merge, I will `git tag` the merge commit, create a github release page, and do the standard beta release of that commit.