### PR TITLE
Fix LocalBaseline.py

### DIFF
--- a/pluginExamples/Analysis/LocalBaseline.py
+++ b/pluginExamples/Analysis/LocalBaseline.py
@@ -1,12 +1,9 @@
 import pandas as pd
 import numpy as np
-import logging
 
 import time
 
 from EnlightenPlugin import *
-
-log = logging.getLogger(__name__)
 
 class LocalBaseline(EnlightenPluginBase):
 

--- a/pluginExamples/EnlightenPlugin.py
+++ b/pluginExamples/EnlightenPlugin.py
@@ -14,6 +14,9 @@ from wasatch.SpectrometerSettings import SpectrometerSettings
 
 import numpy as np
 
+import logging
+log = logging.getLogger(__name__)
+
 ##
 # Abstract Base Class (ABC) for all ENLIGHTEN-compatible plug-ins.
 #


### PR DESCRIPTION
LocalBaseline has been broken on Main for a while. Latest 4.0.14rc is unaffected. This delta restores annotations and the ptable solving part 1 of #261.

Move `import logging` into EnlightenPlugin.py