### PR TITLE
Set Enlighten to default to truncated appending logs

### DIFF
--- a/scripts/Enlighten.py
+++ b/scripts/Enlighten.py
@@ -52,7 +52,10 @@ class EnlightenApplication(object):
 
     ## Parse command-line arguments
     def parse_args(self, argv):
+
+        # SB: this doesn't show up anywhere bc logging is not yet configured
         log.debug("Process args: %s", argv)
+
         self.args = self.parser.parse_args(argv)
         if self.args is None:
             return
@@ -78,16 +81,21 @@ class EnlightenApplication(object):
     #
     def create_parser(self):
         parser = argparse.ArgumentParser(description="acquire from specified device, display line graph")
-        parser.add_argument("--log-level",          type=str, default="info",       help="logging level",    choices=['debug', 'info', 'warning', 'error', 'critical'])
-        parser.add_argument("--log-append",         action="store_true",            help="append to existing logfile")
-        parser.add_argument("--logfile",            type=str,                       help="Explicit path for the logfile")
-        parser.add_argument("--max-memory-growth",  type=int, default=0,            help="Automatically exit after this percent memory growth (0 for never, 100 = doubling)")
-        parser.add_argument("--run-sec",            type=int, default=0,            help="Automatically exit after this many seconds (0 for never)")
-        parser.add_argument("--serial-number",      type=str,                       help="only connect to specified serial number")
-        parser.add_argument("--set-all-dfu",        action="store_true",            help="set spectrometers to DFU mode as soon as they connect")
-        parser.add_argument("--stylesheet-path",    type=str,                       help="Path to CSS directory")
-        parser.add_argument("--headless",           action="store_true",            help="Run Enlighten without GUI")
-        parser.add_argument("--plugin",             type=str,                       help="Plugin name")
+
+        # This code was like a spreadsheet when I found it, leaning into that
+        # use :set nowrap in vim
+        # TODO: everything should have a default -- do not rely on empty args
+        #                  | parameter name       | type    | default             | action             | choices                                                  | help |
+        parser.add_argument("--log-level",         type=str, default="info",                            choices=['debug', 'info', 'warning', 'error', 'critical'], help="logging level")
+        parser.add_argument("--log-append",                  default="LIMIT_20MB", action="store_true", choices=["False", "True", "LIMIT_20MB"],                   help="append to existing logfile")
+        parser.add_argument("--logfile",           type=str,                                                                                                       help="Explicit path for the logfile")
+        parser.add_argument("--max-memory-growth", type=int, default=0,                                                                                            help="Automatically exit after this percent memory growth (0 for never, 100 = doubling)")
+        parser.add_argument("--run-sec",           type=int, default=0,                                                                                            help="Automatically exit after this many seconds (0 for never)")
+        parser.add_argument("--serial-number",     type=str,                                                                                                       help="only connect to specified serial number")
+        parser.add_argument("--set-all-dfu",                                       action="store_true",                                                            help="set spectrometers to DFU mode as soon as they connect")
+        parser.add_argument("--stylesheet-path",   type=str,                                                                                                       help="Path to CSS directory")
+        parser.add_argument("--headless",                                          action="store_true",                                                            help="Run Enlighten without GUI")
+        parser.add_argument("--plugin",            type=str,                                                                                                       help="Plugin name")
         return parser
 
     ##

--- a/scripts/Enlighten.py
+++ b/scripts/Enlighten.py
@@ -79,7 +79,6 @@ class EnlightenApplication(object):
     ## Defines the command-line arguments and their defaults
     #
     def create_parser(self):
-<<<<<<< HEAD
         parser = argparse.ArgumentParser(description="acquire from specified device, display line graph",
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
@@ -95,7 +94,6 @@ class EnlightenApplication(object):
         parser.add_argument("--serial-number",     type=str,                                                                                                                help="only connect to specified serial number")
         parser.add_argument("--set-all-dfu",                                       action="store_true",                                                                     help="set spectrometers to DFU mode as soon as they connect")
         parser.add_argument("--stylesheet-path",   type=str,                                                                                                                help="path to CSS directory")
-        parser.add_argument("--headless",                                          action="store_true",                                                                     help="Run Enlighten without GUI")
         parser.add_argument("--window-state",      type=str, default="floating",                        choices=["floating", "maximized", "fullscreen", "minimized"],       help="window initial state", )
         parser.add_argument("--plugin",            type=str,                                                                                                                help="plugin name to start enabled")
 

--- a/scripts/Enlighten.py
+++ b/scripts/Enlighten.py
@@ -87,7 +87,7 @@ class EnlightenApplication(object):
         # TODO: everything should have a default -- do not rely on empty args
         #                  | parameter name       | type    | default             | action             | choices                                                  | help |
         parser.add_argument("--log-level",         type=str, default="info",                            choices=['debug', 'info', 'warning', 'error', 'critical'], help="logging level")
-        parser.add_argument("--log-append",                  default="LIMIT_20MB", action="store_true", choices=["False", "True", "LIMIT_20MB"],                   help="append to existing logfile")
+        parser.add_argument("--log-append",        type=str, default="LIMIT_20MB",                      choices=["False", "True", "LIMIT_20MB"],                   help="append to existing logfile")
         parser.add_argument("--logfile",           type=str,                                                                                                       help="Explicit path for the logfile")
         parser.add_argument("--max-memory-growth", type=int, default=0,                                                                                            help="Automatically exit after this percent memory growth (0 for never, 100 = doubling)")
         parser.add_argument("--run-sec",           type=int, default=0,                                                                                            help="Automatically exit after this many seconds (0 for never)")
@@ -115,7 +115,7 @@ class EnlightenApplication(object):
         self.splash.setPixmap(pixmap)
         self.splash.show()
 
-        self.main_logger = applog.MainLogger(self.args.log_level, logfile=self.args.logfile, timeout_sec=5, enable_stdout=not self.testing, append=self.args.log_append)
+        self.main_logger = applog.MainLogger(self.args.log_level, logfile=self.args.logfile, timeout_sec=5, enable_stdout=not self.testing, append_arg=self.args.log_append)
 
         # This violates convention but Controller has so many imports that it takes a while to import
         # This needs to occur here because the Qt app needs to be made before the splash screen

--- a/scripts/Enlighten.py
+++ b/scripts/Enlighten.py
@@ -87,7 +87,7 @@ class EnlightenApplication(object):
         # TODO: everything should have a default -- do not rely on empty args
         #                  | parameter name       | type    | default             | action             | choices                                                  | help |
         parser.add_argument("--log-level",         type=str, default="info",                            choices=['debug', 'info', 'warning', 'error', 'critical'], help="logging level")
-        parser.add_argument("--log-append",        type=str, default="LIMIT_20MB",                      choices=["False", "True", "LIMIT_20MB"],                   help="append to existing logfile")
+        parser.add_argument("--log-append",        type=str, default="LIMIT",                      choices=["False", "True", "LIMIT"],                   help="append to existing logfile")
         parser.add_argument("--logfile",           type=str,                                                                                                       help="Explicit path for the logfile")
         parser.add_argument("--max-memory-growth", type=int, default=0,                                                                                            help="Automatically exit after this percent memory growth (0 for never, 100 = doubling)")
         parser.add_argument("--run-sec",           type=int, default=0,                                                                                            help="Automatically exit after this many seconds (0 for never)")


### PR DESCRIPTION
Using `--log-append=LIMIT` as the new default, Enlighten will append to the log file but keep it within a certain size.

The size limit is decided by Wasatch.PY. Currently it is 20mb, but we want to tweak that based on a few things.

1) start up time. At 20mb it takes more than 60 seconds to open Enlighten. We want to keep launch sub, say, 35 seconds.
2) log coverage time. I'm aiming for 3-10 hours of program time if it's possible.
3) email attachment size. With a max of 25mb on most email clients, that's where 20 mb comes from (~5mb for last session, which may not have a program start truncation)