### PR TITLE
Remove disable laser button when battery low

### DIFF
--- a/enlighten/scope/LaserControlFeature.py
+++ b/enlighten/scope/LaserControlFeature.py
@@ -605,10 +605,6 @@ class LaserControlFeature:
         enough_for_laser = perc >= self.MIN_BATTERY_PERC
         log.debug("enough_for_laser = %s (%.2f%%)" % (enough_for_laser, perc))
 
-        b = self.ctl.form.ui.pushButton_laser_toggle
-        b.setEnabled(enough_for_laser)
-        b.setToolTip("Toggle laser (ctrl-L)" if enough_for_laser else "battery low ({perc:.2f}%)")
-
     def slider_power_callback(self):
         self.slider_stop_usb = False
         position = self.ctl.form.ui.verticalSlider_laser_power.sliderPosition()

--- a/enlighten/scope/RamanModeFeature.py
+++ b/enlighten/scope/RamanModeFeature.py
@@ -78,5 +78,8 @@ class RamanModeFeature(object):
         self.multispec.change_device_setting("acquisition_laser_trigger_enable", self.enabled)
 
         # is there anything else in ENLIGHTEN which might dis/enable the laser button?
+        # SB: yes, LaserControlFeature did when the battery is low (removed in this commit)
+        # this question is the reason we should use expanded names for UI code
+        # self.ctl.form.ui.pushButton_laser_toggle.setEnable is a searchable string
         self.bt_laser.setEnabled(not self.enabled)
         self.bt_laser.setToolTip("disabled in Raman Mode" if self.enabled else "fire laser (ctrl-L)")


### PR DESCRIPTION
This feature was causing issues on a unit plugged to power, removing.

It also had a bug in the tooltip which makes me think the low-battery laser disable was never commonly used.
That is an example of over-engineering, btw.