### PR TITLE
Tensorflow, Py3.11 and PySide 6

### DIFF
--- a/README_CHANGELOG.md
+++ b/README_CHANGELOG.md
@@ -7,9 +7,10 @@
         - Python 3.10 -> 3.11
         - PySide 2 -> 6
         - pyinstaller 4 -> 5
-        - numpy -> 1.26
+        - numpy -> 1.26 (1.24.3?)
         - tensorflow <- 2.13
     - let bootstrap pass compression to InnoSetup (default lzma/max)
+    - change pyinstaller --noconsole to --hide-console to fix pexpect issue
 - 2023-09-29 4.0.19-RC
     - applog tweak
 - 2023-09-29 4.0.18-RC

--- a/README_CHANGELOG.md
+++ b/README_CHANGELOG.md
@@ -2,6 +2,14 @@
 
 # 4.0 GUI Refactoring
 
+- 2023-09-30 4.0.20
+    - updated dependency versions to resolve tensorflow import issue
+        - Python 3.10 -> 3.11
+        - PySide 2 -> 6
+        - pyinstaller 4 -> 5
+        - numpy -> 1.26
+        - tensorflow <- 2.13
+    - let bootstrap pass compression to InnoSetup (default lzma/max)
 - 2023-09-29 4.0.19-RC
     - applog tweak
 - 2023-09-29 4.0.18-RC

--- a/README_WIN10.md
+++ b/README_WIN10.md
@@ -43,9 +43,16 @@ _do not_ quote them (e.g., do *not* type: set PYTHONPATH="..\Wasatch.PY")
 
 ## Activating the environment
 
-When interacting with Enlighten, be sure to activate your shell. This provides access to the dependencies, such as numpy and matplotlib, and it is required for running Enlighten or creating installers.
+When interacting with Enlighten, be sure to activate your shell. This provides 
+access to the dependencies, such as numpy and matplotlib, and it is required for
+running Enlighten or creating installers.
 
     $ scripts\bootstrap.bat activate
+
+Note that conda will "solve" (create) environments much more quickly if you
+use the new libmamba solver described here:
+
+- https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community
 
 ## Running Enlighten
 

--- a/enlighten/BusinessObjects.py
+++ b/enlighten/BusinessObjects.py
@@ -1,6 +1,6 @@
 import logging
-from PySide2.QtGui import QColor
-from PySide2.QtCore import *
+from PySide6.QtGui import QColor
+from PySide6.QtCore import *
 
 log = logging.getLogger(__name__)
 

--- a/enlighten/Controller.py
+++ b/enlighten/Controller.py
@@ -12,10 +12,10 @@ import sys
 import os
 import re
 
-import PySide2
-from PySide2 import QtCore, QtWidgets, QtGui
-from PySide2.QtCore import QObject, QEvent
-from PySide2.QtWidgets import QMessageBox, QVBoxLayout, QWidget, QLabel
+import PySide6
+from PySide6 import QtCore, QtWidgets, QtGui
+from PySide6.QtCore import QObject, QEvent
+from PySide6.QtWidgets import QMessageBox, QVBoxLayout, QWidget, QLabel
 
 from collections import defaultdict
 from threading import Thread
@@ -149,7 +149,7 @@ class Controller:
         log.info("Stylesheet path %s",       self.stylesheet_path)
         log.info("Python version %s",        util.python_version())
         log.info(f"Operating system {sys.platform} {struct.calcsize('P')*8 } bit")
-        log.info("PySide version %s",        PySide2.__version__)
+        log.info("PySide version %s",        PySide6.__version__)
         log.info("PySide QtCore version %s", QtCore.__version__)
         log.info("QtCore version %s",        QtCore.qVersion())
 
@@ -1082,7 +1082,7 @@ class Controller:
 
         def make_shortcut(kseq, callback):
             log.debug(f"setting shortcut from {kseq} to {callback}")
-            shortcut = QtWidgets.QShortcut(QtGui.QKeySequence(kseq), self.form)
+            shortcut = QtGui.QShortcut(QtGui.QKeySequence(kseq), self.form)
             shortcut.activated.connect(callback)
             self.shortcuts[kseq] = shortcut
 

--- a/enlighten/KnowItAll/Feature.py
+++ b/enlighten/KnowItAll/Feature.py
@@ -5,7 +5,7 @@ import logging
 import time
 import os
 
-from PySide2 import QtGui, QtWidgets
+from PySide6 import QtGui, QtWidgets
 
 from .Wrapper import Wrapper
 from .Config  import Config 

--- a/enlighten/MouseWheelFilter.py
+++ b/enlighten/MouseWheelFilter.py
@@ -1,7 +1,7 @@
 import logging
 
-import PySide2
-from PySide2.QtCore import QObject, QEvent
+import PySide6
+from PySide6.QtCore import QObject, QEvent
 
 log = logging.getLogger(__name__)
 

--- a/enlighten/Plugins/PluginController.py
+++ b/enlighten/Plugins/PluginController.py
@@ -16,9 +16,9 @@ import importlib.util
 
 from time import sleep
 from queue import Queue
-from PySide2 import QtGui, QtWidgets, QtCore
-from PySide2.QtWidgets import QMessageBox, QCheckBox
-from PySide2.QtCore import Qt
+from PySide6 import QtGui, QtWidgets, QtCore
+from PySide6.QtWidgets import QMessageBox, QCheckBox
+from PySide6.QtCore import Qt
 
 from .EnlightenApplicationInfoReal import EnlightenApplicationInfoReal
 from .PluginFieldWidget import PluginFieldWidget

--- a/enlighten/Plugins/PluginFieldWidget.py
+++ b/enlighten/Plugins/PluginFieldWidget.py
@@ -1,7 +1,7 @@
 import logging
 
-from PySide2 import QtGui, QtWidgets, QtCore
-from PySide2.QtCore import Qt
+from PySide6 import QtGui, QtWidgets, QtCore
+from PySide6.QtCore import Qt
 
 from wasatch import utils as wasatch_utils
 

--- a/enlighten/Plugins/TableModel.py
+++ b/enlighten/Plugins/TableModel.py
@@ -1,8 +1,8 @@
 import logging
 import pandas as pd
 
-from PySide2 import QtGui, QtWidgets, QtCore
-from PySide2.QtCore import Qt
+from PySide6 import QtGui, QtWidgets, QtCore
+from PySide6.QtCore import Qt
 
 log = logging.getLogger(__name__)
 

--- a/enlighten/ScrollStealFilter.py
+++ b/enlighten/ScrollStealFilter.py
@@ -1,7 +1,7 @@
 import logging
 
-import PySide2
-from PySide2.QtCore import QObject, QEvent
+import PySide6
+from PySide6.QtCore import QObject, QEvent
 
 log = logging.getLogger(__name__)
 

--- a/enlighten/common.py
+++ b/enlighten/common.py
@@ -154,7 +154,7 @@ def msgbox(prompt, title="Alert", buttons=0):
 
     # doing this import within this method to avoid breaking all dependents of common.py
     # not sure that this would break anything, just to be safe -- move up when confident
-    from PySide2.QtWidgets import QMessageBox
+    from PySide6.QtWidgets import QMessageBox
 
     # TODO: see enlighten/ui/BasicWindow.py for an example how to implement this using
     # Enlighten's style. This should always be callable as a single function call without

--- a/enlighten/common.py
+++ b/enlighten/common.py
@@ -13,7 +13,7 @@ application.
       can be modules (files) within it
 """
 
-VERSION = "4.0.19"
+VERSION = "4.0.20"
 
 """ ENLIGHTEN's application version number (checked by scripts/deploy and bootstrap.bat) """
 class Techniques(IntEnum):

--- a/enlighten/device/Authentication.py
+++ b/enlighten/device/Authentication.py
@@ -1,4 +1,4 @@
-from PySide2 import QtCore, QtGui, QtWidgets
+from PySide6 import QtCore, QtGui, QtWidgets
 
 import hashlib
 import logging

--- a/enlighten/device/EEPROMEditor.py
+++ b/enlighten/device/EEPROMEditor.py
@@ -3,7 +3,7 @@ import re
 import logging
 import json
 
-from PySide2 import QtGui, QtWidgets # for product image
+from PySide6 import QtGui, QtWidgets # for product image
 from decimal import *
 from wasatch import utils as wasatch_utils
 

--- a/enlighten/device/EEPROMWriter.py
+++ b/enlighten/device/EEPROMWriter.py
@@ -2,7 +2,7 @@ import os
 import hashlib
 import logging
 
-from PySide2 import QtGui, QtWidgets
+from PySide6 import QtGui, QtWidgets
 
 from enlighten import common
 

--- a/enlighten/device/Multispec.py
+++ b/enlighten/device/Multispec.py
@@ -1,7 +1,7 @@
 import pyqtgraph
 
 from collections import defaultdict
-from PySide2 import QtGui
+from PySide6 import QtGui
 import logging
 import re
 

--- a/enlighten/file_io/Configuration.py
+++ b/enlighten/file_io/Configuration.py
@@ -1,4 +1,4 @@
-from PySide2 import QtCore
+from PySide6 import QtCore
 
 import os
 import re

--- a/enlighten/file_io/FileManager.py
+++ b/enlighten/file_io/FileManager.py
@@ -1,4 +1,4 @@
-from PySide2 import QtCore, QtWidgets
+from PySide6 import QtCore, QtWidgets
 
 import logging
 import re

--- a/enlighten/file_io/LoggingFeature.py
+++ b/enlighten/file_io/LoggingFeature.py
@@ -4,7 +4,7 @@ import logging
 
 from html import escape
 from pygtail import Pygtail 
-from PySide2 import QtCore, QtGui
+from PySide6 import QtCore, QtGui
 
 from wasatch import applog
 

--- a/enlighten/measurement/AreaScanFeature.py
+++ b/enlighten/measurement/AreaScanFeature.py
@@ -5,7 +5,7 @@ import pyqtgraph
 import numpy as np
 import qimage2ndarray
 
-from PySide2 import QtCore, QtWidgets, QtGui
+from PySide6 import QtCore, QtWidgets, QtGui
 
 from enlighten import util
 from enlighten.ScrollStealFilter import ScrollStealFilter

--- a/enlighten/measurement/MeasurementFactory.py
+++ b/enlighten/measurement/MeasurementFactory.py
@@ -1,4 +1,4 @@
-from PySide2 import QtGui
+from PySide6 import QtGui
 
 import pyqtgraph.exporters
 import pyqtgraph

--- a/enlighten/measurement/Measurements.py
+++ b/enlighten/measurement/Measurements.py
@@ -6,7 +6,7 @@ import csv
 import os
 
 import numpy as np
-from PySide2 import QtGui, QtWidgets
+from PySide6 import QtGui, QtWidgets
 
 from enlighten.measurement.Measurement import Measurement
 from SPyC_Writer import SPCFileWriter

--- a/enlighten/network/BLEManager.py
+++ b/enlighten/network/BLEManager.py
@@ -7,8 +7,8 @@ from queue import Queue
 from bleak import discover, BleakClient, BleakScanner
 from bleak.exc import BleakError
 from threading import Thread
-from PySide2 import QtCore, QtWidgets, QtGui
-from PySide2.QtWidgets import QApplication, QDialog, QMainWindow, QPushButton, QVBoxLayout, QLabel
+from PySide6 import QtCore, QtWidgets, QtGui
+from PySide6.QtWidgets import QApplication, QDialog, QMainWindow, QPushButton, QVBoxLayout, QLabel
 
 from wasatch.DeviceID import DeviceID
 

--- a/enlighten/network/CloudManager.py
+++ b/enlighten/network/CloudManager.py
@@ -10,8 +10,8 @@ from decimal import Decimal
 import boto3
 from botocore.config import Config
 
-from PySide2 import QtCore, QtWidgets, QtGui
-from PySide2.QtWidgets import QInputDialog, QLineEdit, QMessageBox, QPushButton, QCheckBox
+from PySide6 import QtCore, QtWidgets, QtGui
+from PySide6.QtWidgets import QInputDialog, QLineEdit, QMessageBox, QPushButton, QCheckBox
 
 from enlighten.common import get_default_data_dir
 from enlighten.device.EEPROMEditor import EEPROMEditor

--- a/enlighten/scope/DarkFeature.py
+++ b/enlighten/scope/DarkFeature.py
@@ -1,9 +1,9 @@
 import datetime
 import logging
 
-import PySide2
+import PySide6
 import pyqtgraph
-from PySide2 import QtCore, QtWidgets, QtGui
+from PySide6 import QtCore, QtWidgets, QtGui
 
 log = logging.getLogger(__name__)
 

--- a/enlighten/scope/DetectorTemperatureFeature.py
+++ b/enlighten/scope/DetectorTemperatureFeature.py
@@ -6,7 +6,7 @@ from enlighten.ScrollStealFilter import ScrollStealFilter
 
 log = logging.getLogger(__name__)
 
-from PySide2 import QtGui, QtCore 
+from PySide6 import QtGui, QtCore 
 
 class DetectorTemperatureFeature:
     """

--- a/enlighten/scope/Graph.py
+++ b/enlighten/scope/Graph.py
@@ -1,8 +1,8 @@
 import logging
 
-import PySide2
+import PySide6
 import pyqtgraph
-from PySide2 import QtCore, QtWidgets, QtGui
+from PySide6 import QtCore, QtWidgets, QtGui
 
 from enlighten import common
 from enlighten.ScrollStealFilter import ScrollStealFilter

--- a/enlighten/scope/GuideFeature.py
+++ b/enlighten/scope/GuideFeature.py
@@ -4,7 +4,7 @@ import logging
 import time
 import os
 
-from PySide2 import QtCore
+from PySide6 import QtCore
 
 log = logging.getLogger(__name__)
 

--- a/enlighten/scope/LaserControlFeature.py
+++ b/enlighten/scope/LaserControlFeature.py
@@ -2,7 +2,7 @@ import time
 from datetime import datetime, timedelta
 import logging
 
-from PySide2 import QtWidgets 
+from PySide6 import QtWidgets 
 
 from enlighten import util
 from enlighten.common import LaserStates

--- a/enlighten/scope/ReferenceFeature.py
+++ b/enlighten/scope/ReferenceFeature.py
@@ -2,9 +2,9 @@ import datetime
 import logging
 import numpy as np
 
-import PySide2
+import PySide6
 import pyqtgraph
-from PySide2 import QtCore, QtWidgets, QtGui
+from PySide6 import QtCore, QtWidgets, QtGui
 
 log = logging.getLogger(__name__)
 

--- a/enlighten/spectra_processes/InterpolationFeature.py
+++ b/enlighten/spectra_processes/InterpolationFeature.py
@@ -1,4 +1,4 @@
-from PySide2 import QtCore
+from PySide6 import QtCore
 
 import logging
 import numpy as np

--- a/enlighten/timing/BatchCollection.py
+++ b/enlighten/timing/BatchCollection.py
@@ -1,4 +1,4 @@
-from PySide2 import QtCore, QtGui
+from PySide6 import QtCore, QtGui
 
 import datetime
 import logging

--- a/enlighten/timing/Ramp.py
+++ b/enlighten/timing/Ramp.py
@@ -1,4 +1,4 @@
-from PySide2 import QtCore
+from PySide6 import QtCore
 import logging
 
 log = logging.getLogger(__name__)

--- a/enlighten/ui/BasicDialog.py
+++ b/enlighten/ui/BasicDialog.py
@@ -1,7 +1,7 @@
 import logging
 import datetime
 
-from PySide2 import QtGui, QtCore, QtWidgets
+from PySide6 import QtGui, QtCore, QtWidgets
 
 log = logging.getLogger(__name__)
 

--- a/enlighten/ui/BasicWindow.py
+++ b/enlighten/ui/BasicWindow.py
@@ -1,7 +1,7 @@
 import logging
 import datetime
 
-from PySide2 import QtGui, QtCore, QtWidgets
+from PySide6 import QtGui, QtCore, QtWidgets
 
 # This line imports the "enlighten_layout.py" module which is generated from 
 # enlighten_layout.ui when you run scripts/rebuild_resources.sh.  

--- a/enlighten/ui/ConfirmWidget.py
+++ b/enlighten/ui/ConfirmWidget.py
@@ -1,6 +1,6 @@
 import logging
 
-from PySide2 import QtGui, QtCore, QtWidgets
+from PySide6 import QtGui, QtCore, QtWidgets
 
 log = logging.getLogger(__name__)
 

--- a/enlighten/ui/GUI.py
+++ b/enlighten/ui/GUI.py
@@ -1,6 +1,6 @@
 import logging
 import pyqtgraph
-from PySide2 import QtGui
+from PySide6 import QtGui
 
 from enlighten.ui.TimeoutDialog import TimeoutDialog
 from enlighten import common

--- a/enlighten/ui/ImageResources.py
+++ b/enlighten/ui/ImageResources.py
@@ -1,6 +1,6 @@
 import logging
 
-from PySide2 import QtCore
+from PySide6 import QtCore
 
 log = logging.getLogger(__name__)
 

--- a/enlighten/ui/Marquee.py
+++ b/enlighten/ui/Marquee.py
@@ -1,6 +1,6 @@
 import webbrowser
 
-from PySide2 import QtCore, QtGui, QtWidgets
+from PySide6 import QtCore, QtGui, QtWidgets
 
 from enlighten import util
 

--- a/enlighten/ui/StatusBarFeature.py
+++ b/enlighten/ui/StatusBarFeature.py
@@ -1,5 +1,5 @@
-from PySide2 import QtCore, QtWidgets, QtGui
-from PySide2.QtWidgets import QMenu
+from PySide6 import QtCore, QtWidgets, QtGui
+from PySide6.QtWidgets import QMenu
 
 import numpy as np
 import logging

--- a/enlighten/ui/StatusIndicators.py
+++ b/enlighten/ui/StatusIndicators.py
@@ -1,4 +1,4 @@
-from PySide2 import QtCore
+from PySide6 import QtCore
 
 import datetime
 import logging

--- a/enlighten/ui/ThumbnailWidget.py
+++ b/enlighten/ui/ThumbnailWidget.py
@@ -1,4 +1,4 @@
-from PySide2 import QtGui, QtCore, QtWidgets
+from PySide6 import QtGui, QtCore, QtWidgets
 import pyqtgraph
 
 from datetime import datetime

--- a/enlighten/ui/TimeoutDialog.py
+++ b/enlighten/ui/TimeoutDialog.py
@@ -6,8 +6,8 @@
 
 import logging
 from fileinput import close
-from PySide2 import QtCore, QtWidgets
-from PySide2.QtWidgets import QMessageBox
+from PySide6 import QtCore, QtWidgets
+from PySide6.QtWidgets import QMessageBox
 
 log = logging.getLogger(__name__)
 

--- a/environments/conda-win10.yml
+++ b/environments/conda-win10.yml
@@ -10,11 +10,9 @@ dependencies:
     - pexpect
     - pip
     - psutil
-    - python==3.10.*
+    - python
     - pytest
     - scipy
     - xlwt
     - qimage2ndarray
     - pywin32
-
-# installed from pip: PySide2 pygtail pyusb pywavelets superman pyqtgraph

--- a/environments/conda-win10.yml
+++ b/environments/conda-win10.yml
@@ -5,7 +5,7 @@ channels:
     - conda-forge
 
 dependencies:
-    - numpy
+    - numpy==1.26
     - pandas
     - pexpect
     - pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ spc_spectra
 libusb 
 seabreeze 
 boto3 
-tensorflow 
+tensorflow==2.13
 bleak 
 pyftdi 
 adafruit-blinka

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Requirements without specifiers. Grab latest of each package
-PySide2 
+PySide6
 pygtail 
 pyusb 
 pefile 

--- a/scripts/Application_InnoSetup.iss
+++ b/scripts/Application_InnoSetup.iss
@@ -26,7 +26,8 @@ DefaultDirName={commonpf}\Wasatch Photonics\{#MyAppName}
 DisableDirPage=yes
 DefaultGroupName=Wasatch Photonics
 OutputDir=windows_installer
-Compression=lzma
+; change to lzma/max for major releases
+Compression=lzma/fast
 SolidCompression=yes
 ArchitecturesAllowed=x64
 ArchitecturesInstallIn64BitMode=x64

--- a/scripts/Application_InnoSetup.iss
+++ b/scripts/Application_InnoSetup.iss
@@ -26,8 +26,8 @@ DefaultDirName={commonpf}\Wasatch Photonics\{#MyAppName}
 DisableDirPage=yes
 DefaultGroupName=Wasatch Photonics
 OutputDir=windows_installer
-; change to lzma/max for major releases
-Compression=lzma/fast
+; lzma/fast for test builds, lzma/max for public releases
+Compression={#COMPRESSION}
 SolidCompression=yes
 ArchitecturesAllowed=x64
 ArchitecturesInstallIn64BitMode=x64

--- a/scripts/Enlighten.py
+++ b/scripts/Enlighten.py
@@ -28,6 +28,10 @@ from wasatch   import applog
 
 log = logging.getLogger(__name__)
 
+# if "PRELOAD_TENSORFLOW" in os.environ:
+# import tensorflow
+# import tensorflow.python.framework.dtypes
+# import tensorflow.python.framework._dtypes
 
 def signal_handler(signal, frame):
     log.critical('Interrupted by Ctrl-C')

--- a/scripts/Enlighten.py
+++ b/scripts/Enlighten.py
@@ -17,9 +17,9 @@ if "macOS" in platform.platform():
 os.environ["BLINKA_FT232H"]="1" # used to allow SPI with FT232H
 
 # Required runtime imports for compiled .exe (see qsvg4.dll in InnoSetup)
-from PySide2 import QtGui, QtCore, QtWidgets, QtSvg, QtXml
-from PySide2.QtWidgets import QSplashScreen
-from PySide2.QtGui import QPixmap, QImageReader
+from PySide6 import QtGui, QtCore, QtWidgets, QtSvg, QtXml
+from PySide6.QtWidgets import QSplashScreen
+from PySide6.QtGui import QPixmap, QImageReader
 
 from enlighten.ui.BasicWindow import BasicWindow
 from enlighten import common

--- a/scripts/Enlighten.py
+++ b/scripts/Enlighten.py
@@ -28,11 +28,6 @@ from wasatch   import applog
 
 log = logging.getLogger(__name__)
 
-# if "PRELOAD_TENSORFLOW" in os.environ:
-# import tensorflow
-# import tensorflow.python.framework.dtypes
-# import tensorflow.python.framework._dtypes
-
 def signal_handler(signal, frame):
     log.critical('Interrupted by Ctrl-C')
     sys.exit(0)

--- a/scripts/bootstrap.bat
+++ b/scripts/bootstrap.bat
@@ -14,7 +14,6 @@ set "regenerate_qt=0"
 set "pyinstaller=0"
 set "innosetup=0"
 set "runtests=0"
-
 set "virtspec=0"
 
 REM Convoluted but safe way to generate an audible bell from a .bat
@@ -130,7 +129,7 @@ echo %date% %time% ======================================================
 REM capture start time
 set TIME_START=%time%
 set PYTHONUTF8=1
-set PYTHONPATH=.;..\Wasatch.PY;pluginExamples;%CONDA_PREFIX%\lib\site-packages;enlighten\assets\uic_qrc
+set PYTHONPATH=.;..\Wasatch.PY;..\SPyC_Writer\src;pluginExamples;%CONDA_PREFIX%\lib\site-packages;enlighten\assets\uic_qrc
 echo PYTHONPATH = %PYTHONPATH%
 
 if exist "C:\Program Files (x86)" (
@@ -425,7 +424,16 @@ if "%innosetup%" == "1" (
     echo %date% %time% Running Inno Setup
     echo %date% %time% ======================================================
     echo.
-    "%PROGRAM_FILES_X86%\Inno Setup 6\iscc.exe" /DENLIGHTEN_VERSION=%ENLIGHTEN_VERSION% scripts\Application_InnoSetup.iss
+
+    if "%COMPRESSION%" == "" (
+        rem caller may set it to lzma/fast for speed
+        set "COMPRESSION=lzma/max"
+    )
+
+    "%PROGRAM_FILES_X86%\Inno Setup 6\iscc.exe" ^
+        /DENLIGHTEN_VERSION=%ENLIGHTEN_VERSION% ^
+        /DCOMPRESSION=%COMPRESSION% ^
+        scripts\Application_InnoSetup.iss
     if %errorlevel% neq 0 goto script_failure
 
     echo.

--- a/scripts/bootstrap.bat
+++ b/scripts/bootstrap.bat
@@ -387,6 +387,16 @@ if "%pyinstaller%" == "1" (
     REM --windowed ^
 
     REM pyinstaller --distpath="scripts/built-dist" --workpath="scripts/work-path" --noconfirm --clean scripts/enlighten.spec
+    REM --hidden-import="numpy.array_api._dtypes" ^
+    REM --hidden-import="tensorboard.compat.tensorflow_stub.dtypes" ^
+    REM --hidden-import="ml_dtypes" ^
+    REM --hidden-import="tensorflow.include.external.ml_dtypes" ^
+    REM --hidden-import="tensorflow.python.framework.dtypes" ^
+    REM --hidden-import="tensorflow.python.framework.flexible_dtypes" ^
+    REM --hidden-import="tensorflow.python.ml_dtype" ^
+    REM --hidden-import="tensorflow.python.ops.numpy_ops.np_dtype" ^
+    REM --hidden-import="tensorflow.tsl.python.lib.core.ml_dtype" ^
+    REM --hidden-import="tensorflow.tsl.python.lib.core.pywrap_ml_dtypes" ^
 
     pyinstaller ^
         --distpath="scripts/built-dist" ^

--- a/scripts/bootstrap.bat
+++ b/scripts/bootstrap.bat
@@ -375,15 +375,11 @@ if "%pyinstaller%" == "1" (
     echo %date% %time% Running PyInstaller OPTIONAL
     echo %date% %time% ======================================================
     echo.
-    REM remove --windowed to debug the compiled .exe and see Python invocation 
-    REM error messages
-    REM
-    REM --windowed ^
     pyinstaller ^
         --distpath="scripts/built-dist" ^
         --workpath="scripts/work-path" ^
         --noconfirm ^
-        --noconsole ^
+	--hide-console hide-early ^
         --clean ^
         --paths="../Wasatch.PY" ^
         --hidden-import="scipy._lib.messagestream" ^

--- a/scripts/bootstrap.bat
+++ b/scripts/bootstrap.bat
@@ -307,7 +307,8 @@ if "%install_python_deps%" == "1" (
     echo %date% %time% Installing pyinstaller from pip
     echo %date% %time% ======================================================
     echo.
-    pip install pyinstaller==4.5.1
+    rem pip install pyinstaller==4.5.1
+    pip install pyinstaller
     if %errorlevel% neq 0 goto script_failure
 )
 

--- a/scripts/bootstrap.bat
+++ b/scripts/bootstrap.bat
@@ -306,7 +306,6 @@ if "%install_python_deps%" == "1" (
     echo %date% %time% Installing pyinstaller from pip
     echo %date% %time% ======================================================
     echo.
-    rem pip install pyinstaller==4.5.1
     pip install pyinstaller
     if %errorlevel% neq 0 goto script_failure
 )
@@ -376,28 +375,10 @@ if "%pyinstaller%" == "1" (
     echo %date% %time% Running PyInstaller OPTIONAL
     echo %date% %time% ======================================================
     echo.
-
-    rem address bug in current pyinstaller?
-    rem copy enlighten\assets\uic_qrc\images\EnlightenIcon.ico .
-    rem set SPECPATH=%cd%/scripts
-
     REM remove --windowed to debug the compiled .exe and see Python invocation 
     REM error messages
     REM
     REM --windowed ^
-
-    REM pyinstaller --distpath="scripts/built-dist" --workpath="scripts/work-path" --noconfirm --clean scripts/enlighten.spec
-    REM --hidden-import="numpy.array_api._dtypes" ^
-    REM --hidden-import="tensorboard.compat.tensorflow_stub.dtypes" ^
-    REM --hidden-import="ml_dtypes" ^
-    REM --hidden-import="tensorflow.include.external.ml_dtypes" ^
-    REM --hidden-import="tensorflow.python.framework.dtypes" ^
-    REM --hidden-import="tensorflow.python.framework.flexible_dtypes" ^
-    REM --hidden-import="tensorflow.python.ml_dtype" ^
-    REM --hidden-import="tensorflow.python.ops.numpy_ops.np_dtype" ^
-    REM --hidden-import="tensorflow.tsl.python.lib.core.ml_dtype" ^
-    REM --hidden-import="tensorflow.tsl.python.lib.core.pywrap_ml_dtypes" ^
-
     pyinstaller ^
         --distpath="scripts/built-dist" ^
         --workpath="scripts/work-path" ^

--- a/scripts/rebuild_resources.sh
+++ b/scripts/rebuild_resources.sh
@@ -48,8 +48,8 @@ then
 
     TWO_TO_THREE="$CONDA_PREFIX/Scripts/2to3.exe"
 
-    RCC="$CONDA_PREFIX/Scripts/pyside2-rcc.exe"
-    UIC="$CONDA_PREFIX/Scripts/pyside2-uic.exe"
+    RCC="$CONDA_PREFIX/Scripts/pyside6-rcc.exe"
+    UIC="$CONDA_PREFIX/Scripts/pyside6-uic.exe"
 
     # added because recent(?) versions of Git Cmd / Git Bash seem to 
     # automatically launch new shells (run .sh scripts like this one)
@@ -90,6 +90,7 @@ else
     fi
 fi
 
+echo "CONDA_PREFIX= $CONDA_PREFIX"
 echo "QUICK = $QUICK"
 echo "PAUSE = $PAUSE"
 echo "PYTHON= $PYTHON"


### PR DESCRIPTION
This was created as part of #303 to investigate an issue importing Tensorflow in plugins from Enlighten.exe after building with pyinstaller, but has morphed in unexpected directions :-/

- Python 3.10 -> 3.11
- PySide2 -> 6
- PyInstaller 4 -> 5
- numpy -> 1.26
- Tensorflow <- 2.13

Related pulls:
- https://github.com/WasatchPhotonics/SPyC_Writer/pull/5
- https://github.com/WasatchPhotonics/Wasatch.PY/pull/91