### PR TITLE
Windows installer libusb0

### DIFF
--- a/README_CHANGELOG.md
+++ b/README_CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # 4.0 GUI and Plugin Refactoring
 
+- 2023-10-06 4.0.22
+    - bundle libusb0.dll to Windows install folder :-(
 - 2023-10-06 4.0.21
     - automatically retain previous 2MB of existing enlighten.log to aid in fault analysis
 - 2023-09-30 4.0.20

--- a/enlighten/common.py
+++ b/enlighten/common.py
@@ -13,7 +13,7 @@ application.
       can be modules (files) within it
 """
 
-VERSION = "4.0.21"
+VERSION = "4.0.22"
 
 """ ENLIGHTEN's application version number (checked by scripts/deploy and bootstrap.bat) """
 class Techniques(IntEnum):

--- a/environments/conda-win10.yml
+++ b/environments/conda-win10.yml
@@ -5,7 +5,6 @@ channels:
     - conda-forge
 
 dependencies:
-    - numpy==1.26
     - pandas
     - pexpect
     - pip

--- a/run.bat
+++ b/run.bat
@@ -6,4 +6,4 @@ REM Note be sure to do this, or run with -X utf8
 set PYTHONUTF8=1
 set QT_AUTO_SCREEN_SCALE_FACTOR=1
 
-python scripts\Enlighten.py --log-level debug 1>enlighten.out 2>enlighten.err
+python scripts\Enlighten.py --log-append False --log-level debug 1>enlighten.out 2>enlighten.err

--- a/scripts/bootstrap.bat
+++ b/scripts/bootstrap.bat
@@ -379,12 +379,13 @@ if "%pyinstaller%" == "1" (
         --distpath="scripts/built-dist" ^
         --workpath="scripts/work-path" ^
         --noconfirm ^
-	--hide-console hide-early ^
+        --hide-console hide-early ^
         --clean ^
         --paths="../Wasatch.PY" ^
         --hidden-import="scipy._lib.messagestream" ^
         --hidden-import="scipy.special.cython_special" ^
         --hidden-import="tensorflow" ^
+        --add-data="support_files/libusb_drivers/amd64/libusb0.dll:." ^
         --icon "../enlighten/assets/uic_qrc/images/EnlightenIcon.ico" ^
         --specpath="%cd%/scripts" ^
         --exclude-module _bootlocale ^


### PR DESCRIPTION
Something broke when tensorflow forced some dependency updates, because now we're getting the old "libusb backend not found" when run from the compiled Windows installer, even though it works fine from source.  Testing possible fixes...