### PR TITLE
resolve #183 invalid default string next to Save .ini File btn

### DIFF
--- a/enlighten/file_io/Configuration.py
+++ b/enlighten/file_io/Configuration.py
@@ -14,7 +14,7 @@ from enlighten import common
 
 log = logging.getLogger(__name__)
 
-class Configuration(object):
+class Configuration:
     """
     This is a wrapper over ConfigParser.  It adds the following features:
     
@@ -87,6 +87,8 @@ class Configuration(object):
         self.load_defaults()
         self.stub_missing()
         self.stub_test() # MZ: I don't think this belongs in Configuration
+
+        self.lb_save_result.setText("calibration will be saved to %s" % self.pathname)
 
         try:
             self.reload()


### PR DESCRIPTION
#183 is labeled as closed, so why does this old branch appear ahead of main by one commit ?

We can even see the line this introduces on main:
https://github.com/WasatchPhotonics/ENLIGHTEN/blob/82d913ce2497e89d68243dc057d81d8c62c203e6/enlighten/file_io/Configuration.py#L92