### PR TITLE
Show Enlighten version in help text

### DIFF
--- a/scripts/Enlighten.py
+++ b/scripts/Enlighten.py
@@ -79,9 +79,9 @@ class EnlightenApplication(object):
     ## Defines the command-line arguments and their defaults
     #
     def create_parser(self):
-        parser = argparse.ArgumentParser(description="acquire from specified device, display line graph",
+        parser = argparse.ArgumentParser(description="ENLIGHTEN %s" % common.VERSION,
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-
+        
         # This code was like a spreadsheet when I found it, leaning into that
         # use :set nowrap in vim
         # TODO: everything should have a default -- do not rely on empty args


### PR DESCRIPTION
Address #291 

* --help and "--invalid-arg" both produced help message already
* The only change is to include the Enlighten version number in the help text
* Some existing text that seemed out of place was removed

Before
```
Y:\projects\Enlighten-B\scripts\built-dist\Enlighten>Enlighten.exe --help
usage: Enlighten.exe [-h] [--log-level {debug,info,warning,error,critical}] [--log-append {False,True,LIMIT}] [--logfile LOGFILE] [--max-memory-growth MAX_MEMORY_GROWTH]
                     [--run-sec RUN_SEC] [--serial-number SERIAL_NUMBER] [--set-all-dfu] [--stylesheet-path STYLESHEET_PATH] [--window-state {floating,maximized,fullscreen,minimized}]      
                     [--plugin PLUGIN]

acquire from specified device, display line graph

options:
  -h, --help            show this help message and exit
  --log-level {debug,info,warning,error,critical}
                        logging level (default: info)
  --log-append {False,True,LIMIT}
                        append to existing logfile (default: LIMIT)
  --logfile LOGFILE     explicit path for the logfile (default: None)
  --max-memory-growth MAX_MEMORY_GROWTH
                        automatically exit after this percent memory growth (0 for never, 100 = doubling) (default: 0)
  --run-sec RUN_SEC     automatically exit after this many seconds (0 for never) (default: 0)
  --serial-number SERIAL_NUMBER
                        only connect to specified serial number (default: None)
  --set-all-dfu         set spectrometers to DFU mode as soon as they connect (default: False)
  --stylesheet-path STYLESHEET_PATH
                        path to CSS directory (default: None)
  --window-state {floating,maximized,fullscreen,minimized}
                        window initial state (default: floating)
  --plugin PLUGIN       plugin name to start enabled (default: None)

Y:\projects\Enlighten-B\scripts\built-dist\Enlighten>
```

After
```
Y:\projects\Enlighten-B\scripts\built-dist\Enlighten>Enlighten.exe --help
usage: Enlighten.exe [-h] [--log-level {debug,info,warning,error,critical}] [--log-append {False,True,LIMIT}] [--logfile LOGFILE] [--max-memory-growth MAX_MEMORY_GROWTH]
                     [--run-sec RUN_SEC] [--serial-number SERIAL_NUMBER] [--set-all-dfu] [--stylesheet-path STYLESHEET_PATH] [--window-state {floating,maximized,fullscreen,minimized}]      
                     [--plugin PLUGIN]

ENLIGHTEN 4.0.24

options:
  -h, --help            show this help message and exit
  --log-level {debug,info,warning,error,critical}
                        logging level (default: info)
  --log-append {False,True,LIMIT}
                        append to existing logfile (default: LIMIT)
  --logfile LOGFILE     explicit path for the logfile (default: None)
  --max-memory-growth MAX_MEMORY_GROWTH
                        automatically exit after this percent memory growth (0 for never, 100 = doubling) (default: 0)
  --run-sec RUN_SEC     automatically exit after this many seconds (0 for never) (default: 0)
  --serial-number SERIAL_NUMBER
                        only connect to specified serial number (default: None)
  --set-all-dfu         set spectrometers to DFU mode as soon as they connect (default: False)
  --stylesheet-path STYLESHEET_PATH
                        path to CSS directory (default: None)
  --window-state {floating,maximized,fullscreen,minimized}
                        window initial state (default: floating)
  --plugin PLUGIN       plugin name to start enabled (default: None)

Y:\projects\Enlighten-B\scripts\built-dist\Enlighten>
```