### PR TITLE
Sb persist sg

### DIFF
--- a/enlighten/BusinessObjects.py
+++ b/enlighten/BusinessObjects.py
@@ -607,6 +607,7 @@ class BusinessObjects:
 
         self.header("instantiating BoxcarFeature")
         ctl.boxcar = BoxcarFeature(
+            ctl,
             bt_dn                       = sfu.pushButton_boxcar_half_width_dn,
             bt_up                       = sfu.pushButton_boxcar_half_width_up,
             spinbox                     = sfu.spinBox_boxcar_half_width,
@@ -617,6 +618,7 @@ class BusinessObjects:
 
         self.header("instantiating IntegrationTimeFeature")
         ctl.integration_time_feature = IntegrationTimeFeature(
+            ctl,
             bt_dn                       = sfu.pushButton_integration_time_ms_dn,
             bt_up                       = sfu.pushButton_integration_time_ms_up,
             marquee                     = ctl.marquee,
@@ -625,7 +627,7 @@ class BusinessObjects:
             spinbox                     = sfu.spinBox_integration_time_ms)
 
         self.header("instantiating GainDBFeature")
-        ctl.gain_db_feature = GainDBFeature(ctl = ctl)
+        ctl.gain_db_feature = GainDBFeature(ctl)
 
         self.header("instantiating BLEManager")
         ctl.ble_manager = BLEManager(

--- a/enlighten/file_io/Configuration.py
+++ b/enlighten/file_io/Configuration.py
@@ -502,19 +502,14 @@ class Configuration:
             for spec in self.multispec.get_spectrometers():
                 if spec.device:
                     settings = spec.settings
-                    eeprom = settings.eeprom
-                    state = settings.state
-                    sn = eeprom.serial_number
+                    eeprom = spec.settings.eeprom
+                    state = spec.settings.state
+                    sn = spec.settings.eeprom.serial_number
                     if sn is None or len(sn) == 0:
                         log.error("declining to save settings for unit without serial number")
                         continue
 
                     log.info("saving config for %s", sn)
-
-                    # these application-session settings can always be saved
-                    self.set(sn, "integration_time_ms", state.integration_time_ms)
-                    self.set(sn, "boxcar_half_width", state.boxcar_half_width)
-                    self.set(sn, "gain_db", state.gain_db)
 
                     # only save EEPROM overrides if explicitly instructed
                     if full:

--- a/enlighten/scope/GainDBFeature.py
+++ b/enlighten/scope/GainDBFeature.py
@@ -150,6 +150,9 @@ class GainDBFeature:
 
     def set_db(self, db):
         
+        # save gain_db to application state
+        self.ctl.multispec.set_state("gain_db", db)
+
         # persist gain_db in .ini
         self.ctl.config.set(self.ctl.multispec.current_spectrometer().settings.eeprom.serial_number, "gain_db", ms)
 

--- a/enlighten/scope/GainDBFeature.py
+++ b/enlighten/scope/GainDBFeature.py
@@ -97,9 +97,6 @@ class GainDBFeature:
         spec = self.ctl.multispec.current_spectrometer()
         spec.settings.state.gain_db = spec.settings.eeprom.detector_gain
 
-        self.ctl.form.ui.doubleSpinBox_gain.setValue(spec.settings.state.gain_db)
-        log.debug("GainDBFeature.init_hotplug: initialized to %.2f", spec.settings.state.gain_db)
-
     # called by initialize_new_device a little after the other function
     def reset(self, hotplug=False):
         if not self.update_visibility():
@@ -154,7 +151,7 @@ class GainDBFeature:
         self.ctl.multispec.set_state("gain_db", db)
 
         # persist gain_db in .ini
-        self.ctl.config.set(self.ctl.multispec.current_spectrometer().settings.eeprom.serial_number, "gain_db", ms)
+        self.ctl.config.set(self.ctl.multispec.current_spectrometer().settings.eeprom.serial_number, "gain_db", db)
 
         # send gain update message to device
         self.ctl.multispec.change_device_setting("detector_gain", db)
@@ -165,20 +162,14 @@ class GainDBFeature:
 
     def up_callback(self):
         util.incr_spinbox(self.ctl.form.ui.doubleSpinBox_gain)
+        self.set_db(self.ctl.form.ui.doubleSpinBox_gain.value())
 
     def dn_callback(self):
         util.decr_spinbox(self.ctl.form.ui.doubleSpinBox_gain)
+        self.set_db(self.ctl.form.ui.doubleSpinBox_gain.value())
 
     def sync_slider_to_spinbox_callback(self):
-        self.ctl.form.ui.doubleSpinBox_gain.setValue(self.ctl.form.ui.slider_gain.value()) 
+        self.set_db(self.ctl.form.ui.slider_gain.value()) 
 
     def sync_spinbox_to_slider_callback(self):
-        db = self.ctl.form.ui.doubleSpinBox_gain.value()
-
-        self.ctl.form.ui.slider_gain.blockSignals(True)
-        self.ctl.form.ui.slider_gain.setValue(db)
-        self.ctl.form.ui.slider_gain.blockSignals(False)
-
-        self.ctl.multispec.set_state("gain_db", db)
-        self.ctl.multispec.change_device_setting("detector_gain", db)
-
+        self.set_db(self.ctl.form.ui.doubleSpinBox_gain.value())

--- a/enlighten/scope/IntegrationTimeFeature.py
+++ b/enlighten/scope/IntegrationTimeFeature.py
@@ -15,7 +15,7 @@ class IntegrationTimeFeature(object):
     TENTHS_TO_SEC = 0.1
     MAX_SLIDER_SEC = 5
 
-    def __init__(self,
+    def __init__(self, ctl,
             bt_dn,
             bt_up,
             marquee,
@@ -23,6 +23,8 @@ class IntegrationTimeFeature(object):
             slider,
             spinbox
         ):
+
+        self.ctl = ctl
 
         self.bt_dn      = bt_dn
         self.bt_up      = bt_up
@@ -99,8 +101,13 @@ class IntegrationTimeFeature(object):
 
         if hotplug:
             log.debug("forcing integration time downstream on hotplug")
-            self.multispec.set_state("integration_time_ms", now_ms)
+            
+            # persist integration time in .ini
+            self.ctl.config.set(self.ctl.multispec.current_spectrometer().settings.eeprom.serial_number, "integration_time_ms", ms)
+
+            # send integration time change to hardware
             spec.change_device_setting("integration_time_ms", now_ms)
+
             spec.reset_acquisition_timeout()
 
     ## If you're not sure which function to call, call this one.
@@ -139,8 +146,10 @@ class IntegrationTimeFeature(object):
         self.slider.setValue(tenths)
         self.slider.blockSignals(False)
 
-        # actually send the change downstream
-        self.multispec.set_state("integration_time_ms", ms)
+        # persist integration time in .ini
+        self.ctl.config.set(self.ctl.multispec.current_spectrometer().settings.eeprom.serial_number, "integration_time_ms", ms)
+
+        # send changed integration time to hardware
         self.multispec.change_device_setting("integration_time_ms", ms)
 
         # reset timeouts

--- a/enlighten/scope/IntegrationTimeFeature.py
+++ b/enlighten/scope/IntegrationTimeFeature.py
@@ -102,6 +102,9 @@ class IntegrationTimeFeature(object):
         if hotplug:
             log.debug("forcing integration time downstream on hotplug")
             
+            # save integration time to application state
+            self.multispec.set_state("integration_time_ms", now_ms)
+
             # persist integration time in .ini
             self.ctl.config.set(self.ctl.multispec.current_spectrometer().settings.eeprom.serial_number, "integration_time_ms", ms)
 
@@ -145,6 +148,9 @@ class IntegrationTimeFeature(object):
         self.slider.blockSignals(True)
         self.slider.setValue(tenths)
         self.slider.blockSignals(False)
+
+        # save integration time to application state
+        self.multispec.set_state("integration_time_ms", now_ms)
 
         # persist integration time in .ini
         self.ctl.config.set(self.ctl.multispec.current_spectrometer().settings.eeprom.serial_number, "integration_time_ms", ms)

--- a/enlighten/scope/IntegrationTimeFeature.py
+++ b/enlighten/scope/IntegrationTimeFeature.py
@@ -26,28 +26,27 @@ class IntegrationTimeFeature(object):
 
         self.ctl = ctl
 
-        self.bt_dn      = bt_dn
-        self.bt_up      = bt_up
-        self.marquee    = marquee
-        self.multispec  = multispec
-        self.slider     = slider
-        self.spinbox    = spinbox
+        self.bt_dn = bt_dn
+        self.bt_up = bt_up
+        self.marquee = marquee
+        self.multispec = multispec
+        self.slider = slider
+        self.spinbox = spinbox
 
         # bindings
-        self.slider     .valueChanged       .connect(self.sync_slider_to_spinbox_callback)
-        self.spinbox    .valueChanged       .connect(self.sync_spinbox_to_slider_callback)
-        self.slider                         .installEventFilter(MouseWheelFilter(self.slider))
-        self.spinbox                        .installEventFilter(ScrollStealFilter(self.spinbox))
-        self.bt_up      .clicked            .connect(self.up_callback)
-        self.bt_dn      .clicked            .connect(self.dn_callback)
+        self.slider.valueChanged.connect(self.slider_callback)
+        self.spinbox.valueChanged.connect(self.spinbox_callback)
+        self.bt_up.clicked.connect(self.up_callback)
+        self.bt_dn.clicked.connect(self.dn_callback)
+
+        self.slider.installEventFilter(MouseWheelFilter(self.slider))
+        self.spinbox.installEventFilter(ScrollStealFilter(self.spinbox))
 
     # called by initialize_new_device on hotplug, BEFORE reading / applying .ini
     def init_hotplug(self):
         spec = self.multispec.current_spectrometer()
         if spec is None:
             return
-
-        self.spinbox.setValue(spec.settings.eeprom.startup_integration_time_ms)
 
     # called by initialize_new_device a little after the other function
     def reset(self, hotplug=False):
@@ -70,6 +69,9 @@ class IntegrationTimeFeature(object):
         if (max_tenths * self.TENTHS_TO_SEC > self.MAX_SLIDER_SEC):
             max_tenths = self.MAX_SLIDER_SEC / self.TENTHS_TO_SEC
 
+        now_ms = self.ctl.config.get_float(self.ctl.multispec.current_spectrometer().settings.eeprom.serial_number, "integration_time_ms")
+        log.info("integration time from config: %d" % now_ms)
+        
         self.slider.blockSignals(True)
         self.slider.setMinimum(min_tenths)
         self.slider.setMaximum(max_tenths)
@@ -85,28 +87,21 @@ class IntegrationTimeFeature(object):
         # case for some hotplug events).
         if hotplug:
             # cap at 1sec, else application seems dead
-            now_ms = min(max_ms, max(min_ms, min(1000, self.spinbox.value())))
-        else:
-            now_ms = spec.settings.state.integration_time_ms
+            now_ms = min(max_ms, max(min_ms, min(1000, now_ms)))
+            
         self.spinbox.blockSignals(True)
         self.spinbox.setMinimum(min_ms)
         self.spinbox.setMaximum(max_ms)
         self.spinbox.blockSignals(False)
 
-        # signals enabled, so will propogate everywhere
-        self.spinbox.setValue  (now_ms)
+        self.set_ms(now_ms)
 
         log.info("spinbox integration limits updated to (%.2f, %.2fms) (current %.2fms)",
             self.spinbox.minimum(), self.spinbox.maximum(), self.spinbox.value())
 
         if hotplug:
-            log.debug("forcing integration time downstream on hotplug")
-            
             # save integration time to application state
             self.multispec.set_state("integration_time_ms", now_ms)
-
-            # persist integration time in .ini
-            self.ctl.config.set(self.ctl.multispec.current_spectrometer().settings.eeprom.serial_number, "integration_time_ms", ms)
 
             # send integration time change to hardware
             spec.change_device_setting("integration_time_ms", now_ms)
@@ -119,40 +114,21 @@ class IntegrationTimeFeature(object):
     # the new value downstream (to one if unlocked, all if locked), plus updates states
     # appropriately.
     def set_ms(self, ms):
-        self.spinbox.setValue(ms)
 
-    def up_callback(self):
-        util.incr_spinbox(self.spinbox)
-
-    def dn_callback(self):
-        util.decr_spinbox(self.spinbox)
-
-    def sync_slider_to_spinbox_callback(self):
-        tenths = self.slider.value()
-        ms = tenths / self.MILLISEC_TO_TENTHS
-
-        if ms < self.spinbox.minimum():
-            ms = self.spinbox.minimum()
-        elif ms > self.spinbox.maximum():
-            ms = self.spinbox.maximum()
-
-        log.debug("sync_to_spinbox_callback: slider %.2f tenths to %.2f ms", tenths, ms)
-        self.spinbox.setValue(ms) 
-
-    def sync_spinbox_to_slider_callback(self):
-        ms = self.spinbox.value()
-
-        # update other GUI widget WITHOUT triggering its callback (but apparently abiding its limits)
-        tenths = int(round(ms * self.MILLISEC_TO_TENTHS, 0))
-        log.debug("sync_spinbox_to_slider: spinbox %.2f ms to %d tenths", ms, tenths)
         self.slider.blockSignals(True)
+        tenths = int(round(ms * self.MILLISEC_TO_TENTHS, 0))
         self.slider.setValue(tenths)
         self.slider.blockSignals(False)
 
+        self.spinbox.blockSignals(True)
+        self.spinbox.setValue(ms) 
+        self.spinbox.blockSignals(False)
+
         # save integration time to application state
-        self.multispec.set_state("integration_time_ms", now_ms)
+        self.multispec.set_state("integration_time_ms", ms)
 
         # persist integration time in .ini
+        log.debug("integration time to config: %d", ms)
         self.ctl.config.set(self.ctl.multispec.current_spectrometer().settings.eeprom.serial_number, "integration_time_ms", ms)
 
         # send changed integration time to hardware
@@ -180,6 +156,28 @@ class IntegrationTimeFeature(object):
                 self.marquee.info("Recommend re-taking reference with new integration time")
             elif refresh_dark:
                 self.marquee.info("Recommend re-taking dark with new integration time")
+
+    def up_callback(self):
+        util.incr_spinbox(self.spinbox)
+        self.set_ms(ms) 
+
+    def dn_callback(self):
+        util.decr_spinbox(self.spinbox)
+        self.set_ms(ms) 
+
+    def slider_callback(self):
+        tenths = self.slider.value()
+        ms = tenths / self.MILLISEC_TO_TENTHS
+
+        if ms < self.spinbox.minimum():
+            ms = self.spinbox.minimum()
+        elif ms > self.spinbox.maximum():
+            ms = self.spinbox.maximum()
+        self.set_ms(ms) 
+
+    def spinbox_callback(self):
+        ms = self.spinbox.value()
+        self.set_ms(ms)
 
     def set_focus(self):
         self.spinbox.setFocus()

--- a/enlighten/spectra_processes/BoxcarFeature.py
+++ b/enlighten/spectra_processes/BoxcarFeature.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 class BoxcarFeature(object):
     """ Encapsulate the high-frequency noise smoothing "boxcar" filter run at the end of post-processing. """
     
-    def __init__(self,
+    def __init__(self, ctl
             bt_dn,
             bt_up,
             spinbox,
@@ -18,6 +18,8 @@ class BoxcarFeature(object):
             multispec,
             page_nav,
             ):
+        
+        self.ctl = ctl
 
         self.bt_dn      = bt_dn
         self.bt_up      = bt_up
@@ -36,7 +38,9 @@ class BoxcarFeature(object):
 
     def update_from_gui(self):
         value = self.spinbox.value()
-        self.multispec.set_state("boxcar_half_width", value)
+
+        # persist boxcar in .ini
+        self.ctl.config.set(self.ctl.multispec.current_spectrometer().settings.eeprom.serial_number, "boxcar_half_width", ms)
 
         if value > 0:
             self.spinbox.setToolTip("boxcar half-width of %d pixels (%d-pixel moving average)" % (value, value * 2 + 1))

--- a/enlighten/spectra_processes/BoxcarFeature.py
+++ b/enlighten/spectra_processes/BoxcarFeature.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 class BoxcarFeature(object):
     """ Encapsulate the high-frequency noise smoothing "boxcar" filter run at the end of post-processing. """
     
-    def __init__(self, ctl
+    def __init__(self, ctl,
             bt_dn,
             bt_up,
             spinbox,

--- a/enlighten/spectra_processes/BoxcarFeature.py
+++ b/enlighten/spectra_processes/BoxcarFeature.py
@@ -43,7 +43,7 @@ class BoxcarFeature(object):
         self.multispec.set_state("boxcar_half_width", value)
 
         # persist boxcar in .ini
-        self.ctl.config.set(self.ctl.multispec.current_spectrometer().settings.eeprom.serial_number, "boxcar_half_width", ms)
+        self.ctl.config.set(self.ctl.multispec.current_spectrometer().settings.eeprom.serial_number, "boxcar_half_width", value)
 
         if value > 0:
             self.spinbox.setToolTip("boxcar half-width of %d pixels (%d-pixel moving average)" % (value, value * 2 + 1))

--- a/enlighten/spectra_processes/BoxcarFeature.py
+++ b/enlighten/spectra_processes/BoxcarFeature.py
@@ -39,6 +39,9 @@ class BoxcarFeature(object):
     def update_from_gui(self):
         value = self.spinbox.value()
 
+        # save boxcar to application state
+        self.multispec.set_state("boxcar_half_width", value)
+
         # persist boxcar in .ini
         self.ctl.config.set(self.ctl.multispec.current_spectrometer().settings.eeprom.serial_number, "boxcar_half_width", ms)
 


### PR DESCRIPTION
## What has changed

Adjustments to be more compliant with style guide #240 

Gain, Integration Time, and Boxcar had the following change of pattern for updating persistent parameters. The result is one less state-to-state copying.
<img width="1118" alt="image" src="https://github.com/WasatchPhotonics/ENLIGHTEN/assets/124081765/20f22f48-8549-4e03-802b-94b9a4430189">

Gain had a rewrite of its load from persistence such that the code is structured to match the searchpath specified in the issue above.

## Todo

- ~Test persistence of these three variables on XS~
- ~scan for references of state.gain, etc~