### PR TITLE
Sb no truthy

### DIFF
--- a/enlighten/ui/GUI.py
+++ b/enlighten/ui/GUI.py
@@ -6,8 +6,6 @@ from enlighten.ui.TimeoutDialog import TimeoutDialog
 from enlighten import common
 from enlighten.common import msgbox
 
-from wasatch import utils as wasatch_utils
-
 log = logging.getLogger(__name__)
 
 ##
@@ -97,7 +95,7 @@ class GUI(object):
         if button is None:
             return
 
-        if wasatch_utils.truthy(flag):
+        if flag:
             self.ctl.stylesheets.apply(button, "red_gradient_button")
         else:
             self.ctl.stylesheets.apply(button, "gray_gradient_button")


### PR DESCRIPTION
Reviewing the code that colors the laser button I didn't find any obvious cause for a gray button that says "Turn Laser Off".

But I did see this strange utility call. It's defined in Wasatch.PY.

```python
def truthy(flag):
    if flag is None:
        return False

    try:
        if len(flag) > 0:
            return True
    except:
        pass

    return True if flag else False
```

This is the same thing as how Python already treats values in if-statements.
```
>>> bool(None)
False
>>> bool([])
False
>>> bool(0)
False
>>> bool("")
False

>>> truthy(None)
False
>>> truthy([])
False
>>> truthy(0)
False
>>> truthy("")
False

# also note that
if bool(x):
    something()
# is the same as
if x:
    something()
```

Is there any reason this was done besides an abundance of caution in the wake of uncertainty how python treats these cases?