### PR TITLE
Fix graph for XS

### DIFF
--- a/enlighten/scope/Graph.py
+++ b/enlighten/scope/Graph.py
@@ -325,7 +325,7 @@ class Graph(object):
             log.debug("added raw curve '%s'", name)
 
         if rehide:
-            self.ctl.rehide_curves()
+            self.ctl.update_feature_visibility()
 
         return curve
 


### PR DESCRIPTION
Graph still referenced a non-existent function. When that is updated, the XS is able to show spectra on this branch again.

Once this is merged to mzeig-roi-handles, we'll need to re-review it before merging to 4.1.0-dev