### PR TITLE
Small tweaks encountered while testing 4.1.0-dev

### DIFF
--- a/enlighten/measurement/Measurement.py
+++ b/enlighten/measurement/Measurement.py
@@ -749,7 +749,7 @@ class Measurement:
             self.save_spc_file()
             saved = True
 
-        if self.save_options.save_dx():
+        if self.ctl.save_options.save_dx():
             self.save_dx_file()
             saved = True
 
@@ -1159,7 +1159,7 @@ class Measurement:
         if self.settings and self.settings.eeprom:
             data['SPECTROMETER/DATA SYSTEM'] = f"{self.settings.eeprom.serial_number} {self.settings.eeprom.model}"
 
-        current_x = self.save_options.multispec.graph.current_x_axis 
+        current_x = self.ctl.graph.current_x_axis 
         if current_x == common.Axes.WAVELENGTHS:
             data['y']        = np.array(self.processed_reading.processed)
             data['x']        = np.asarray(self.settings.wavelengths)

--- a/pluginExamples/EnlightenPlugin.py
+++ b/pluginExamples/EnlightenPlugin.py
@@ -43,7 +43,6 @@ class EnlightenPluginBase:
         # these can be set by functional-plugins to autogenerate EPC
         self.name = None
         self._fields = []
-        self._events = []
         self.is_blocking = False
         self.block_enlighten = False
         self.auto_enable = False
@@ -209,7 +208,6 @@ class EnlightenPluginBase:
         return EnlightenPluginConfiguration(
             name = self.name, 
             fields = self._fields,
-            events = self._events,
             is_blocking = self.is_blocking,
             block_enlighten = self.block_enlighten,
             has_other_graph = self.has_other_graph,


### PR DESCRIPTION
- deprecated EnlightenPlugin._events[] in favor of .events{}
- fixed missed Measurement 'ctl' refactors