### PR TITLE
innosetup support win11

### DIFF
--- a/scripts/bootstrap.bat
+++ b/scripts/bootstrap.bat
@@ -34,6 +34,8 @@ if "%1" == "pyinstaller" (
     goto args_parsed
 )
 if "%1" == "innosetup" (
+    set "regenerate_qt=1"
+    set "pyinstaller=1"
     set "innosetup=1"
     goto args_parsed
 )


### PR DESCRIPTION
I'm not certain that this is what did it, but if I recall correctly, the following would work on win10 but not win11.

```
$ scripts\bootstrap.bat pyinstaller
...
$ scripts\bootstrap.bat innosetup
...
```

When I changed the _innosetup_ build task to contain pyinstaller then it seems to have worked even on Win11.