### PR TITLE
Remove product config from eepromeditor

### DIFF
--- a/enlighten/assets/uic_qrc/enlighten_layout.ui
+++ b/enlighten/assets/uic_qrc/enlighten_layout.ui
@@ -5320,16 +5320,6 @@ QComboBox QListView
                            </widget>
                           </item>
                           <item row="15" column="0">
-                           <widget class="QLineEdit" name="lineEdit_ee_product_configuration" />
-                          </item>
-                          <item row="15" column="1">
-                           <widget class="QLabel" name="label_185">
-                            <property name="text">
-                             <string>Product Configuration</string>
-                            </property>
-                           </widget>
-                          </item>
-                          <item row="16" column="0">
                            <widget class="QSpinBox" name="spinBox_ee_subformat">
                             <property name="minimumSize">
                              <size>
@@ -5339,7 +5329,7 @@ QComboBox QListView
                             </property>
                            </widget>
                           </item>
-                          <item row="16" column="1">
+                          <item row="15" column="1">
                            <widget class="QLabel" name="label_69">
                             <property name="text">
                              <string>Page 6-7 Subformat</string>

--- a/enlighten/device/EEPROMEditor.py
+++ b/enlighten/device/EEPROMEditor.py
@@ -101,7 +101,6 @@ class EEPROMEditor:
             "max_laser_power_mw": "max_laser_power_mW",
             "min_laser_power_mw": "min_laser_power_mW",
             "excitation_wavelength_nm": "excitation_nm",
-            "product_config": "product_configuration",
             "rel_int_corr_order": "raman_intensity_calibration_order",
             "bin2x2": "bin_2x2",
             "flip_x_axis": "invert_x_axis",
@@ -170,7 +169,7 @@ class EEPROMEditor:
         self.bind_lineEdit        (cfu.lineEdit_ee_wavelength_coeff_2,        "wavelength_coeffs", 2)
         self.bind_lineEdit        (cfu.lineEdit_ee_wavelength_coeff_3,        "wavelength_coeffs", 3)
         self.bind_lineEdit        (cfu.lineEdit_ee_wavelength_coeff_4,        "wavelength_coeffs", 4)
-        self.bind_lineEdit        (cfu.lineEdit_ee_product_configuration,     "product_configuration")
+
         self.bind_lineEdit        (cfu.lineEdit_ee_raman_intensity_coeff_0,   "raman_intensity_coeffs", 0)
         self.bind_lineEdit        (cfu.lineEdit_ee_raman_intensity_coeff_1,   "raman_intensity_coeffs", 1)
         self.bind_lineEdit        (cfu.lineEdit_ee_raman_intensity_coeff_2,   "raman_intensity_coeffs", 2)


### PR DESCRIPTION
Not sure I fully understood the request from the issue, but Product Configuration is definitely gone from the EEPROM Editor.

This is a purely aesthetic change in the sense that the data is still stored there, it's just not being displayed.

@mzieg I didn't understand your comment about 

> make Model char[32]

This sounded like a repartitioning of the EEPROM i.e. expand Model to take up bytes left fro Product Configuration?