### PR TITLE
display empirical indication of laser status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
         - always disable laser in BatchCollection.stop
         - added TakeOneFeature copy-ctor (fixed LaserMode.Spectrum)
     - plugins
+        - fixed bug in base class
         - moved EmissionLines and RamanLines to combobox
     - XS
         - added microcontroller serial number

--- a/enlighten/device/LaserControlFeature.py
+++ b/enlighten/device/LaserControlFeature.py
@@ -17,6 +17,10 @@ class LaserControlFeature:
     BTN_OFF_TEXT = "Turn Laser Off"
     BTN_ON_TEXT = "Turn Laser On"
 
+    MIN_INITIALIZATION_RATIO = 1.20 # 20% increase
+
+    LASER_INIT_TOKEN = "laser_init"
+
     def __init__(self, ctl):
         self.ctl = ctl
 
@@ -26,6 +30,10 @@ class LaserControlFeature:
         self.locked = False
         self.restrictions = set()
         self.observers = { "enabled": set(), "disabled": set() }
+
+        self.initializing = False
+        self.area_at_start = None
+        self.min_at_start = None
 
         cfu = self.ctl.form.ui
 
@@ -267,6 +275,54 @@ class LaserControlFeature:
                 log.info("laser stopped firing (watchdog or interlock?)")
                 self.set_laser_enable(False, spec)
 
+        self.update_initializion_status(reading)
+
+    def update_initializion_status(self, reading):
+        """ Provide empirical feedback on when the laser actually starts firing """
+
+        if not self.initializing:
+            return
+
+        if self.area_at_start is None:
+            # The laser is initializing, but we have not yet characterized
+            # the "dark" spectrum for comparison to determine when the laser 
+            # actually starts emitting.
+            #
+            # I thought about doing a Pearson match, but that seems overkill,
+            # and honestly performs some normalization that isn't entirely
+            # appropriate here. If the laser is firing, the total energy received
+            # should increase. Conceptually, the area under the curve should
+            # rise. We can just do this in pixel space (sum intensities), as
+            # there doesn't seem any benefit to doing a formal integration 
+            # against wavelength or wavenumber axes.
+            #
+            # The only extra processing I'm doing is a dead-simple baseline 
+            # correction (pull down to zero) so we can more easily compute
+            # a percentage increase for the laser.
+            self.min_at_start = min(reading.spectrum)
+            self.area_at_start = sum([(intensity - self.min_at_start) for intensity in reading.spectrum])
+            log.debug(f"update_initialization_status: min_at_start {self.min_at_start}, area_at_start {self.area_at_start}")
+            return
+
+        # check to see if there's evidence that the laser is firing (at least,
+        # the received energy has perceptibly increased)
+        area = sum([(intensity - self.min_at_start) for intensity in reading.spectrum])
+        ratio = area / self.area_at_start
+        log.debug(f"update_initialization_status: ratio {ratio:0.2f}%")
+
+        if ratio >= self.MIN_INITIALIZATION_RATIO:
+            # declare the laser to be firing
+            log.debug("update_initialization_status: laser believed to be firing")
+
+            self.initializing = False
+            self.min_at_start = None
+            self.area_at_start = None
+
+            self.ctl.marquee.info("laser is warming-up", token=self.LASER_INIT_TOKEN, period_sec=10)
+
+        else:
+            log.debug(f"update_initialization_status: laser does not appear to be firing")
+
     ## So Controller etc don't call directly into internal callbacks
     def toggle_laser(self):
         log.debug("toggle_laser called")
@@ -462,12 +518,13 @@ class LaserControlFeature:
                 log.critical(f"toggle_callback: turning laser OFF even though previous spec.settings.state.laser_enabled was {spec.settings.state.laser_enabled}, as spec.app_state.laser_state is {spec.app_state.laser_state}")
 
         self.set_laser_enable(flag)
-        token = "laser_init"
-
+        
         if flag:
-            self.ctl.marquee.info("laser is initializing and stabilizing for use", token=token, period_sec=10)
+            self.ctl.marquee.info("laser is initializing", token=self.LASER_INIT_TOKEN, period_sec=10) # consider persist=True
         else:
-            self.ctl.marquee.clear(token=token)
+            self.ctl.marquee.clear(token=self.LASER_INIT_TOKEN)
+
+        self.initializing = flag
 
     ## 
     # This gets called when the "front" (Scope) laser excitation value is changed.

--- a/enlighten/post_processing/BaselineCorrection.py
+++ b/enlighten/post_processing/BaselineCorrection.py
@@ -76,7 +76,6 @@ class BaselineCorrection:
         self.airpls_smoothness_param = 20
         self.airpls_max_iters = 500
         self.airpls_conv_thresh = 8e-4
-        self.airpls_whittaker_deriv_order = 2
 
         # first check whether one should be selected and/or enabled
         self.init_from_config()
@@ -153,7 +152,6 @@ class BaselineCorrection:
         set_field("current_algo_name",            self.ctl.config.get      (s, "algo",                         default=None))
         set_field("airpls_max_iters",             self.ctl.config.get_int  (s, "airpls_max_iters",             default=None))
         set_field("airpls_smoothness_param",      self.ctl.config.get_int  (s, "airpls_smoothness_param",      default=None))
-        set_field("airpls_whittaker_deriv_order", self.ctl.config.get_int  (s, "airpls_whittaker_deriv_order", default=None))
         set_field("airpls_conv_thresh",           self.ctl.config.get_float(s, "airpls_conv_thresh",           default=None))
 
     def init_algos(self):
@@ -190,7 +188,6 @@ class BaselineCorrection:
                     algo = AirPLS(smoothness_param      = self.airpls_smoothness_param,
                                   max_iters             = self.airpls_max_iters,
                                   conv_thresh           = self.airpls_conv_thresh)
-                                 #whittaker_deriv_order = self.airpls_whittaker_deriv_order)
                 else:
                     algo = BL_CLASSES[abbr]()
                 self.algos[name] = algo

--- a/enlighten/ui/Marquee.py
+++ b/enlighten/ui/Marquee.py
@@ -21,6 +21,16 @@ class Marquee:
     
     Also provides a button-less "toast" notification that auto-fades over 2sec.
 
+    This class is more complicated than it needs to be for two reasons:
+
+    1. The Marquee used to be animated, with gradual slide-out drawers and such.
+       This is the reason for some of the "schedule" nomenclature and timing.
+       Not really needed anymore, and could be simplified out.
+
+    2. Part of the KnowItAll implementation included the concept of "hazard" vs
+       "benign" identifications. We aren't currently using that, but it may come
+       back.
+
     TODO:
 
     - consider restoring some level of animation (just not moving buttons, like

--- a/plugins/EnlightenPlugin.py
+++ b/plugins/EnlightenPlugin.py
@@ -99,7 +99,7 @@ class EnlightenPluginBase:
         plugin_ctl = self.ctl.plugin_controller
         for pfw in plugin_ctl.plugin_field_widgets:
             if name == pfw.field_name:
-                return pwf
+                return pfw
 
     def get_widget_from_name(self, name):
         pfw = self.get_plugin_field(name)


### PR DESCRIPTION
When firing the laser, grab a copy of the current ambient spectrum, and compare subsequent spectra against that to infer when the laser appears to actually begin firing.

(Branch name: I was going to use Pearson for this, but then decided area-under-the-curve was both simpler and more robust.)