### PR TITLE
[4.0.61] updated laser status messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 4.0 GUI and Plugin Refactoring
 
+- 2024-05-14 4.0.61
+    - changed laser status messages
 - 2024-05-10 4.0.60
     - UI
         - display empirical assessment of laser firing status in Marquee

--- a/enlighten/common.py
+++ b/enlighten/common.py
@@ -13,7 +13,7 @@ application.
       can be modules (files) within it
 """
 
-VERSION = "4.0.60"
+VERSION = "4.0.61"
 
 ctl = None
 

--- a/enlighten/device/LaserControlFeature.py
+++ b/enlighten/device/LaserControlFeature.py
@@ -318,7 +318,7 @@ class LaserControlFeature:
             self.min_at_start = None
             self.area_at_start = None
 
-            self.ctl.marquee.info("laser is warming-up", token=self.LASER_INIT_TOKEN, period_sec=10)
+            self.ctl.marquee.info("laser is firing", token=self.LASER_INIT_TOKEN, period_sec=10)
 
         else:
             log.debug(f"update_initialization_status: laser does not appear to be firing")
@@ -520,7 +520,7 @@ class LaserControlFeature:
         self.set_laser_enable(flag)
         
         if flag:
-            self.ctl.marquee.info("laser is initializing", token=self.LASER_INIT_TOKEN, period_sec=10) # consider persist=True
+            self.ctl.marquee.info("laser preparing to fire", token=self.LASER_INIT_TOKEN, period_sec=10) # consider persist=True
         else:
             self.ctl.marquee.clear(token=self.LASER_INIT_TOKEN)
 


### PR DESCRIPTION
Per customer request.

Updated messages, when laser_enable first set (during laser warning delay):
<img width="1789" alt="when laser_enable first set (during laser warning delay)" src="https://github.com/WasatchPhotonics/ENLIGHTEN/assets/2125705/08c3d795-92ab-437a-a2fe-6b9b2e76d6b7">

When spectrum clearly indicates laser now firing:
<img width="1789" alt="when spectrum clearly indicates laser now firing" src="https://github.com/WasatchPhotonics/ENLIGHTEN/assets/2125705/bcd3ec9c-bcd3-48be-b2f2-bcd4706392df">
