### PR TITLE
Remove console window from Windows executables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@
 
 - 2024-06-19 4.0.64
     - move pywin32 and spc_spectra to requirements.txt
-    - add cloud-tpu-client to requirements
+    - try to remove console on Win11
+        - add --noconsole to pyinstaller
+        - add FakeOutputHandle to keep Tensorflow happy in absence of sys.stdout
+    - struggle with Microsoft Defender Antivirus
+        - played with Python 3.12, rolled-back to 3.11
+    - accept bizarre 1min+ delay on first Tensorflow initialization post-install/compilation
 - 2024-05-30 4.0.63
     - add default FWHM
     - plugins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## 4.0 GUI and Plugin Refactoring
 
-- 2024-??-?? 4.0.64
+- 2024-06-19 4.0.64
     - move pywin32 and spc_spectra to requirements.txt
+    - add cloud-tpu-client to requirements
 - 2024-05-30 4.0.63
     - add default FWHM
     - plugins

--- a/enlighten/Controller.py
+++ b/enlighten/Controller.py
@@ -136,9 +136,9 @@ class Controller:
         log.info("Python version %s",        util.python_version())
         log.info(f"Operating system {sys.platform} {struct.calcsize('P')*8 } bit")
         if common.use_pyside2():
-            log.info("PySide version %s",        PySide2.__version__)
+            log.info("PySide version %s",    PySide2.__version__)
         else:
-            log.info("PySide version %s",        PySide6.__version__)
+            log.info("PySide version %s",    PySide6.__version__)
         log.info("PySide QtCore version %s", QtCore.__version__)
         log.info("QtCore version %s",        QtCore.qVersion())
 

--- a/enlighten/common.py
+++ b/enlighten/common.py
@@ -132,6 +132,36 @@ class LaserStates(IntEnum):
     REQUESTED   = 1
     FIRING      = 2
 
+class FakeOutputHandle:
+    """
+    We [think we] need to build Windows installers with PyInstaller. However, 
+    since Win11 came out, PyInstaller's compiled executables tend to display a 
+    black "console window" on either Win10 or Win11, depending on which 
+    PyInstaller options you use. The only way we've found to completely hide
+    the console window is with --noconsole.
+
+    However, some Python packages (like Tensorflow) really, really want to write
+    directly to stdout, and raise exceptions if they can't. So this class is
+    provided to represent a fake output filehandle which we can assign to 
+    sys.stdout or sys.stderr, even when our executing environment doesn't provide
+    those things.
+    """
+    def __init__(self, name):
+        self.name = name
+
+    def write(self, msg):
+        if msg is None:
+            return
+        msg = msg.strip()
+        if msg:
+            log.debug(f"{self.name}: {msg}")
+
+    def flush(self):
+        pass
+
+    def reconfigure(self, *args, **kwargs):
+        pass
+
 def get_default_data_dir():
     """
     Return the path used for all Enlighten data except for spectra. This will be something like "~/Documents/EnlightenSpectra"

--- a/enlighten/common.py
+++ b/enlighten/common.py
@@ -13,7 +13,7 @@ application.
       can be modules (files) within it
 """
 
-VERSION = "4.0.63"
+VERSION = "4.0.64"
 
 ctl = None
 

--- a/enlighten/ui/ImageResources.py
+++ b/enlighten/ui/ImageResources.py
@@ -30,7 +30,7 @@ class ImageResources:
         while it.hasNext():
             pathname = it.next()
             self.resources.append(pathname)
-            log.debug(f"  {pathname}")
+            # log.debug(f"  {pathname}")
 
         self.resources.sort()
         log.debug(f"found {len(self.resources)} resources")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 tensorflow==2.13.1
-cloud-tpu-client
+#cloud-tpu-client
 numpy
 PySide6
 PyQt5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 tensorflow==2.13.1
+cloud-tpu-client
 numpy
 PySide6
 PyQt5

--- a/scripts/Application_InnoSetup.iss
+++ b/scripts/Application_InnoSetup.iss
@@ -54,7 +54,7 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 ; "Regular" files
 Source: "built-dist\*"; DestDir: "{app}"; Flags: recursesubdirs ignoreversion
 
-; I forget what needs this
+; possibly for https://pyinstaller.org/en/v6.0.0/usage.html#windows
 Source: "support_files\msvcr100.dll"; DestDir: "{app}\enlighten\"; Flags: recursesubdirs ignoreversion
 
 ; Include libusb dll's. Note this is only required for appveyor builds. Building on a Windows 10

--- a/scripts/Enlighten.py
+++ b/scripts/Enlighten.py
@@ -118,6 +118,10 @@ class EnlightenApplication:
             append_arg=str(self.args.log_append)
         )
 
+        # now that we've configured the logger, redirect stdout to our logger
+        # (so we can use Tensorflow without a console window)
+        sys.stdout = common.FakeOutputHandle("FakeStdout")
+
         # This violates convention but Controller has so many imports that it 
         # takes a while to import. This needs to occur here because the Qt app 
         # needs to be made before the splash screen. So it has to occur in this 

--- a/scripts/bootstrap.bat
+++ b/scripts/bootstrap.bat
@@ -21,7 +21,9 @@ REM without inserting control characters which confuse unix2dos etc.
 REM https://stackoverflow.com/a/64515648
 set "RING_BELL=echo x|choice /n 2>nul"
 
-set ENLIGHTEN_VENV=%HOME%\enlighten_py311
+set ENLIGHTEN_PYTHON_REV=3.11
+set ENLIGHTEN_VENV=%HOME%\enlighten_py%ENLIGHTEN_PYTHON_REV%
+echo Using ENLIGHTEN_PYTHON_REV %ENLIGHTEN_PYTHON_REV%
 echo Using ENLIGHTEN_VENV at %ENLIGHTEN_VENV%
 
 if "%2" == "virtspec" (
@@ -230,7 +232,7 @@ if "%configure_venv%" == "1" (
     echo %date% %time% Create venv
     echo %date% %time% ======================================================
     echo.
-    python3.11 -m venv %ENLIGHTEN_VENV%
+    python%ENLIGHTEN_PYTHON_REV% -m venv %ENLIGHTEN_VENV%
     if %errorlevel% neq 0 goto script_failure
 )
 
@@ -299,14 +301,14 @@ if "%pyinstaller%" == "1" (
     echo %date% %time% Running PyInstaller
     echo %date% %time% ======================================================
     echo.
-    REM hide-early worked on Win10 but not Win11
-    REM hide-late doesn't work on Win10
+    REM --hide-console hide-early worked on Win10 but not Win11
+    REM --hide-console hide-late doesn't work on Win10
     pyinstaller ^
         --distpath="scripts/built-dist" ^
         --workpath="scripts/work-path" ^
         --noconfirm ^
         --python-option "X utf8" ^
-        --hide-console hide-early ^
+        --hide-console hide-late ^
         --clean ^
         --paths="../Wasatch.PY" ^
         --hidden-import="scipy._lib.messagestream" ^

--- a/scripts/bootstrap.bat
+++ b/scripts/bootstrap.bat
@@ -308,7 +308,7 @@ if "%pyinstaller%" == "1" (
         --workpath="scripts/work-path" ^
         --noconfirm ^
         --python-option "X utf8" ^
-        --hide-console hide-late ^
+        --noconsole ^
         --clean ^
         --paths="../Wasatch.PY" ^
         --hidden-import="scipy._lib.messagestream" ^


### PR DESCRIPTION
Final PR:
- remove console on Win11
- add FakeOutputHandle to keep Tensorflow happy in absence of sys.stdout

Original branch intention:

Was testing a Tensorflow model, and perhaps my laptop was just under unusually high strain, but it failed while loading the model and logged this message:

`tensorflow DEBUG Falling back to TensorFlow client; we recommended you install the Cloud TPU client directly with pip install cloud-tpu-client`

(Note message was emitted directly from the tensorflow library, which was interesting.)
I added this package, and everything ran perfectly.