### PR TITLE
[#428] prompt user before overwriting files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 4.0 GUI and Plugin Refactoring
 
+- 2024-??-?? 4.0.65
+    - [#428] verify before overwriting files
 - 2024-06-19 4.0.64
     - move pywin32 and spc_spectra to requirements.txt
     - try to remove console on Win11


### PR DESCRIPTION
Note we already checked for overwriting when exporting from Measurements, or renaming an existing Measurement. This is just for generating new individual Measurement files. 

Also, this is not applied to row-ordered "Dash" files, because those are traditionally used for "append" use-cases and already have bespoke logic for deciding when it's valid to start a new file or add to an old one.