### PR TITLE
[#426] allow more than 500 thumbnails on the clipboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 4.0 GUI and Plugin Refactoring
 
+- 2024-??-?? 4.0.65
+    - support --max-thumbnails cmd-line arg and ENLIGHTEN_MAX_THUMBNAILS environment variable
 - 2024-06-19 4.0.64
     - move pywin32 and spc_spectra to requirements.txt
     - try to remove console on Win11

--- a/enlighten/Controller.py
+++ b/enlighten/Controller.py
@@ -87,6 +87,7 @@ class Controller:
                 log_queue,
                 log_level         = "INFO",
                 max_memory_growth = 0,
+                max_thumbnails    = 500,
                 run_sec           = 0,
                 serial_number     = None,
                 stylesheet_path   = None,
@@ -106,6 +107,7 @@ class Controller:
         self.log_queue              = log_queue # currently needed for KnowItAll.Wrapper
         self.log_level              = log_level # passed to LoggingFeature and WasatchDeviceWrapper/Worker
         self.max_memory_growth      = max_memory_growth
+        self.max_thumbnails         = max_thumbnails
         self.run_sec                = run_sec
         self.dialog_open            = False
         self.serial_number_desired  = serial_number

--- a/enlighten/measurement/Measurements.py
+++ b/enlighten/measurement/Measurements.py
@@ -28,8 +28,6 @@ log = logging.getLogger(__name__)
 # of ThumbnailWidgets which fill the left-hand capture column in the GUI.
 class Measurements:
 
-    MAX_MEASUREMENT_COUNT = 500
-
     # I see no need to deepcopy this Singleton (and this allows us to deepcopy
     # Measurements freely).
     def __deepcopy__(self, memo):
@@ -251,7 +249,7 @@ class Measurements:
             return
 
         # enforce resource limits
-        while self.count() >= Measurements.MAX_MEASUREMENT_COUNT:
+        while self.count() >= self.ctl.max_thumbnails:
             log.debug("enforcing resource limits")
             self.delete_oldest()
 

--- a/scripts/Enlighten.py
+++ b/scripts/Enlighten.py
@@ -91,6 +91,7 @@ class EnlightenApplication:
         parser.add_argument("--log-append",        type=str, default="False",     help="append to existing logfile", choices=["False", "True", "LIMIT"])
         parser.add_argument("--logfile",           type=str,                      help="explicit path for the logfile")
         parser.add_argument("--max-memory-growth", type=int, default=0,           help="automatically exit after this percent memory growth (0 for never, 100 = doubling)")
+        parser.add_argument("--max-thumbnails",    type=int,                      help="maximum number of thumbnails in measurement clipboard", default=os.environ.get("ENLIGHTEN_MAX_THUMBNAILS", 500))
         parser.add_argument("--run-sec",           type=int, default=0,           help="automatically exit after this many seconds (0 for never)")
         parser.add_argument("--serial-number",     type=str,                      help="only connect to specified serial number")
         parser.add_argument("--set-all-dfu",       action="store_true",           help="set spectrometers to DFU mode as soon as they connect")
@@ -137,6 +138,7 @@ class EnlightenApplication:
             log_level         = self.args.log_level,
             log_queue         = self.main_logger.log_queue,
             max_memory_growth = self.args.max_memory_growth,
+            max_thumbnails    = self.args.max_thumbnails,
             run_sec           = self.args.run_sec,
             serial_number     = self.args.serial_number,
             stylesheet_path   = self.args.stylesheet_path,


### PR DESCRIPTION
- support --max-thumbnails cmd-line arg and ENLIGHTEN_MAX_THUMBNAILS environment variable

I don't think this will be a sufficiently common use-case to require persistence through Configuration, GUI spinners etc. The request has come up exactly once in 7 years.