### PR TITLE
fix copy-to-clipboard after connecting to plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - 2024-??-?? 4.0.68
     - change StatusBar frame count from ProcessedReading to Reading.session_count
     - clarified BatchCollection "explain this" re: collection timeout
+    - [#462] fix system clipboard copy after connecting to plugin
     - [#460] fix issues loading saved spectra
         - fix logging bug in MeasurementFactory
         - fixed missed calls to add_renamable from #452

--- a/enlighten/scope/Graph.py
+++ b/enlighten/scope/Graph.py
@@ -461,14 +461,28 @@ class Graph:
             # iterate over every curve on the graph
             for curve in self.plot.listDataItems():
                 spectrum = curve.getData()[-1]
-                if spectrum is not None and len(spectrum) == len(x_axis):
-                    spectra.append(spectrum)
+                if spectrum is not None:
+                    if len(spectrum) == len(x_axis):
+                        spectra.append(spectrum)
+                    else:
+                        log.debug(f"not copying curve {curve} to clipboard because len(spectrum) {len(spectrum)} != len(x_axis) {len(x_axis)}")
+                else:
+                    log.debug(f"not copying curve {curve} to clipboard because spectrum is None")
         else:
             # multiple spectrometers, so x-axis and lengths can vary
             spectra = []
             for curve in self.plot.listDataItems():
-                spectra.append(curve.getData()[0])
-                spectra.append(curve.getData()[-1])
+                data = curve.getData()
+                x = data[0]
+                y = data[-1]
+                spectra.append(x)
+                spectra.append(y)
+
+        # ignore callbacks with only one column -- these may be specious callbacks 
+        # from empty plugin graph (x-axis only)
+        if len(spectra) < 2:
+            log.debug("declining to copy single-dimension array to clipboard")
+            return
 
         self.ctl.clipboard.copy_spectra(spectra)
 


### PR DESCRIPTION
When you press ctrl-C to copy the on-screen spectra to the system clipboard, the event is being sent to both the main scope and the plugin graph. If the plugin graph is empty, it's still copying an empty spectra (x-axis only) to the clipboard, overwriting the scope data (which gets written to the clipboard first). Ideally we should probably append BOTH graphs' data to the clipboard, but for now a quick fix is that if the plugin graph is empty, at least don't stomp the scope data.