### PR TITLE
Ensure plugin metadata stomps standard ENLIGHTEN fields in export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Version History
 
+- 2024-08-29 4.1.1
+    - ensure metadata 'stomped' by plugins appear in exports
 - 2024-08-22 4.1.0
     - public release
 

--- a/enlighten/common.py
+++ b/enlighten/common.py
@@ -13,7 +13,7 @@ application.
       can be modules (files) within it
 """
 
-VERSION = "4.1.0"
+VERSION = "4.1.1"
 
 ctl = None
 

--- a/enlighten/measurement/Measurement.py
+++ b/enlighten/measurement/Measurement.py
@@ -815,10 +815,6 @@ class Measurement:
         orig = field
         field = field.lower()
 
-        # if this field has already been computed, use cached
-        if orig in self.metadata:
-            return self.metadata[orig]
-
         # allow plugins to stomp standard metadata
         if self.processed_reading.plugin_metadata is not None:
             pm = self.processed_reading.plugin_metadata
@@ -826,6 +822,10 @@ class Measurement:
                 if field == k.lower():
                     log.debug(f"get_metadata: stomping {k} from plugin metadata {v}")
                     return v
+
+        # if this field has already been computed, use cached
+        if orig in self.metadata:
+            return self.metadata[orig]
 
         wavecal = self.settings.get_wavecal_coeffs()
 


### PR DESCRIPTION
A plugin was correctly populating "Declared Match" via the ProcessedReading.plugin_metadata dict, but Measurement.get_metadata was not taking that field from plugin_metadata because the dict key was already found cached in "standard metadata". The checks in get_metadata have been flipped to ensure plugin values "trump" default ENLIGHTEN settings.