### PR TITLE
Auto-Raman Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Version History
 
-- 2024-??-?? 4.1.8
+- 2024-10-09 4.1.8
     - AutoRaman
-        - add "Retain Auto-Raman Settings" checkbox
-        - add scan averaging to Auto-Raman settings retained
+        - add "auto-save" checkbox (persisted)
+        - add "Retain Auto-Raman Settings" checkbox (persisted)
+        - add scan averaging to retained Auto-Raman settings
         - if not retaining, still use (but don't store) averaged dark
-        - expose maxScansToAverage (NOT IMPLEMENTED)
-        - add "auto-save" checkbox (NOT IMPLEMENTED)
+        - expose maxScansToAverage AutoRamanRequest option
+        - add Ctrl-* shortcut
 - 2024-10-03 4.1.7
     - EEPROMEditor
         - added disable_ble_power

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,17 @@
 # Version History
 
+- 2024-10-10 4.1.11
+    - fixed Ctrl-G gain shortcut 
+    - renamed "ROI Start/Stop Lines" in saved Measurements
+    - AutoRaman
+        - auto-save bugfix
+        - bugfix when NOT retaining settings
+        - fixed saved Measurement metadata when NOT retaining settings
+        - restore previous int/gain on cancel
+- 2024-10-10 4.1.10
+    - bumped revision to test updated wasatch.IMX385 class
 - 2024-10-09 4.1.9
-    - flipped IMX385 first pixel color
+    - flipped IMX385 first pixel from red -> blue
 - 2024-10-09 4.1.8
     - AutoRaman
         - add "auto-save" checkbox (persisted)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
         - if not retaining, still use (but don't store) averaged dark
         - expose maxScansToAverage AutoRamanRequest option
         - add Ctrl-* shortcut
+    - added "SSC Enabled" FeatureMask bit on EEPROM Editor
 - 2024-10-03 4.1.7
     - EEPROMEditor
         - added disable_ble_power

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Version History
 
+- 2024-??-?? 4.1.8
+    - AutoRaman
+        - add "Retain Auto-Raman Settings" checkbox
+        - add scan averaging to Auto-Raman settings retained
+        - if not retaining, still use (but don't store) averaged dark
+        - expose maxScansToAverage (NOT IMPLEMENTED)
+        - add "auto-save" checkbox (NOT IMPLEMENTED)
 - 2024-10-03 4.1.7
     - EEPROMEditor
         - added disable_ble_power

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Version History
 
+- 2024-10-09 4.1.9
+    - flipped IMX385 first pixel color
 - 2024-10-09 4.1.8
     - AutoRaman
         - add "auto-save" checkbox (persisted)

--- a/enlighten/Controller.py
+++ b/enlighten/Controller.py
@@ -1110,6 +1110,7 @@ class Controller:
         make_shortcut("Ctrl+S", self.vcr_controls.save)
         make_shortcut("Ctrl+T", self.integration_time_feature.set_focus)
         make_shortcut("Ctrl+X", self.page_nav.toggle_expert)
+        make_shortcut("Ctrl+*", self.auto_raman.measure_callback)
 
         # Cursor
         make_shortcut(QtGui.QKeySequence.MoveToPreviousWord, self.cursor.dn_callback) # ctrl-left
@@ -1470,7 +1471,11 @@ class Controller:
         if reading.dark is not None:
 
             # DO NOT blindly store dark if this was an Auto-Raman measurement;
-            # leave that to AutoRamanFeature.process_reading to determine
+            # leave that to AutoRamanFeature.process_reading to determine. Note
+            # that while we do pass the Reading to AutoRamanFeature here, the
+            # Feature doesn't yet save the measurement, even if auto-save is 
+            # enabled, because (for instance) dark correction has not yet been
+            # applied.
             if reading.take_one_request is not None and reading.take_one_request.auto_raman_request:
                 self.auto_raman.process_reading(reading)
             else:

--- a/enlighten/Controller.py
+++ b/enlighten/Controller.py
@@ -1475,7 +1475,8 @@ class Controller:
             # that while we do pass the Reading to AutoRamanFeature here, the
             # Feature doesn't yet save the measurement, even if auto-save is 
             # enabled, because (for instance) dark correction has not yet been
-            # applied.
+            # applied; that is done automatically at the end of 
+            # Controller.process_reading by TakeOneFeature.
             if reading.take_one_request is not None and reading.take_one_request.auto_raman_request:
                 self.auto_raman.process_reading(reading)
             else:

--- a/enlighten/assets/uic_qrc/enlighten_layout.ui
+++ b/enlighten/assets/uic_qrc/enlighten_layout.ui
@@ -16544,6 +16544,22 @@ li.checked::marker { content: "\2612"; }
                              </property>
                             </widget>
                            </item>
+
+                           
+                           <item row="14" column="0" colspan="2">
+                            <widget class="QCheckBox" name="checkBox_auto_raman_retain_settings">
+                             <property name="sizePolicy">
+                              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                               <horstretch>0</horstretch>
+                               <verstretch>0</verstretch>
+                              </sizepolicy>
+                             </property>
+                             <property name="text">
+                              <string>Retain Auto-Raman Settings</string>
+                             </property>
+                            </widget>
+                           </item>
+
                           </layout>
                          </widget>
                         </item>

--- a/enlighten/assets/uic_qrc/enlighten_layout.ui
+++ b/enlighten/assets/uic_qrc/enlighten_layout.ui
@@ -3095,6 +3095,21 @@ QComboBox QListView
                           </item>
 
                           <item row="16" column="0">
+                           <widget class="QCheckBox" name="checkBox_ee_ssc_enabled">
+                            <property name="text">
+                             <string />
+                            </property>
+                           </widget>
+                          </item>
+                          <item row="16" column="1">
+                           <widget class="QLabel" name="label_46_2z">
+                            <property name="text">
+                             <string>SSC Enabled</string>
+                            </property>
+                           </widget>
+                          </item>
+
+                          <item row="17" column="0">
                            <widget class="QDoubleSpinBox" name="doubleSpinBox_ee_excitation_nm_float">
                             <property name="minimumSize">
                              <size>
@@ -3125,14 +3140,14 @@ QComboBox QListView
                             </property>
                            </widget>
                           </item>
-                          <item row="16" column="1">
+                          <item row="17" column="1">
                            <widget class="QLabel" name="label_83">
                             <property name="text">
                              <string>Excitation (nm)</string>
                             </property>
                            </widget>
                           </item>
-                          <item row="17" column="0">
+                          <item row="18" column="0">
                            <widget class="QSpinBox" name="spinBox_ee_slit_size_um">
                             <property name="minimumSize">
                              <size>
@@ -3160,14 +3175,14 @@ QComboBox QListView
                             </property>
                            </widget>
                           </item>
-                          <item row="17" column="1">
+                          <item row="18" column="1">
                            <widget class="QLabel" name="label_86">
                             <property name="text">
                              <string>Slit Size (µm)</string>
                             </property>
                            </widget>
                           </item>
-                          <item row="18" column="0">
+                          <item row="19" column="0">
                            <widget class="QSpinBox" name="spinBox_ee_startup_integration_time_ms">
                             <property name="minimumSize">
                              <size>
@@ -3192,14 +3207,14 @@ QComboBox QListView
                             </property>
                            </widget>
                           </item>
-                          <item row="18" column="1">
+                          <item row="19" column="1">
                            <widget class="QLabel" name="label_13">
                             <property name="text">
                              <string>Startup Integration Time (ms)</string>
                             </property>
                            </widget>
                           </item>
-                          <item row="19" column="0">
+                          <item row="20" column="0">
                            <widget class="QSpinBox" name="spinBox_ee_startup_temp_degC">
                             <property name="minimumSize">
                              <size>
@@ -3224,7 +3239,7 @@ QComboBox QListView
                             </property>
                            </widget>
                           </item>
-                          <item row="19" column="1">
+                          <item row="20" column="1">
                            <widget class="QLabel" name="label_21">
                             <property name="toolTip">
                              <string>°C for detectors (X/XM/XL), or raw DAC for lasers (XS)</string>
@@ -3234,7 +3249,7 @@ QComboBox QListView
                             </property>
                            </widget>
                           </item>
-                          <item row="20" column="0">
+                          <item row="21" column="0">
                            <widget class="QSpinBox" name="spinBox_ee_startup_triggering_scheme">
                             <property name="minimumSize">
                              <size>
@@ -3253,14 +3268,14 @@ QComboBox QListView
                             </property>
                            </widget>
                           </item>
-                          <item row="20" column="1">
+                          <item row="21" column="1">
                            <widget class="QLabel" name="label_29">
                             <property name="text">
                              <string>Startup Triggering Scheme</string>
                             </property>
                            </widget>
                           </item>
-                          <item row="21" column="0">
+                          <item row="22" column="0">
                            <widget class="QDoubleSpinBox" name="doubleSpinBox_ee_detector_gain">
                             <property name="minimumSize">
                              <size>
@@ -3288,7 +3303,7 @@ QComboBox QListView
                             </property>
                            </widget>
                           </item>
-                          <item row="21" column="1">
+                          <item row="22" column="1">
                            <layout class="QHBoxLayout" name="horizontalLayout_92">
                             <item>
                              <widget class="QLabel" name="label_31">
@@ -3330,7 +3345,7 @@ QComboBox QListView
                             </item>
                            </layout>
                           </item>
-                          <item row="22" column="0">
+                          <item row="23" column="0">
                            <widget class="QSpinBox" name="spinBox_ee_detector_offset">
                             <property name="minimumSize">
                              <size>
@@ -3352,14 +3367,14 @@ QComboBox QListView
                             </property>
                            </widget>
                           </item>
-                          <item row="22" column="1">
+                          <item row="23" column="1">
                            <widget class="QLabel" name="label_142">
                             <property name="text">
                              <string>Detector Offset (InGaAs even)</string>
                             </property>
                            </widget>
                           </item>
-                          <item row="23" column="0">
+                          <item row="24" column="0">
                            <widget class="QDoubleSpinBox" name="doubleSpinBox_ee_detector_gain_odd">
                             <property name="minimumSize">
                              <size>
@@ -3384,14 +3399,14 @@ QComboBox QListView
                             </property>
                            </widget>
                           </item>
-                          <item row="23" column="1">
+                          <item row="24" column="1">
                            <widget class="QLabel" name="label_143">
                             <property name="text">
                              <string>Detector Gain (InGaAs odd)</string>
                             </property>
                            </widget>
                           </item>
-                          <item row="24" column="0">
+                          <item row="25" column="0">
                            <widget class="QSpinBox" name="spinBox_ee_detector_offset_odd">
                             <property name="minimumSize">
                              <size>
@@ -3413,21 +3428,21 @@ QComboBox QListView
                             </property>
                            </widget>
                           </item>
-                          <item row="24" column="1">
+                          <item row="25" column="1">
                            <widget class="QLabel" name="label_161">
                             <property name="text">
                              <string>Detector Offset (InGaAs odd)</string>
                             </property>
                            </widget>
                           </item>
-                          <item row="25" column="0">
+                          <item row="26" column="0">
                            <widget class="QLabel" name="label_ee_format">
                             <property name="text">
                              <string>fmt</string>
                             </property>
                            </widget>
                           </item>
-                          <item row="25" column="1">
+                          <item row="26" column="1">
                            <widget class="QLabel" name="label_216">
                             <property name="text">
                              <string>Format</string>
@@ -16545,8 +16560,64 @@ li.checked::marker { content: "\2612"; }
                             </widget>
                            </item>
 
+                           <item row="14" column="0">
+                            <widget class="QSpinBox" name="spinBox_auto_raman_max_avg">
+                             <property name="sizePolicy">
+                              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                               <horstretch>0</horstretch>
+                               <verstretch>0</verstretch>
+                              </sizepolicy>
+                             </property>
+                             <property name="minimumSize">
+                              <size>
+                               <width>100</width>
+                               <height>0</height>
+                              </size>
+                             </property>
+                             <property name="maximumSize">
+                              <size>
+                               <width>100</width>
+                               <height>16777215</height>
+                              </size>
+                             </property>
+                             <property name="focusPolicy">
+                              <enum>Qt::FocusPolicy::StrongFocus</enum>
+                             </property>
+                             <property name="alignment">
+                              <set>Qt::AlignmentFlag::AlignCenter</set>
+                             </property>
+                             <property name="minimum">
+                              <number>1</number>
+                             </property>
+                             <property name="maximum">
+                              <number>1000</number>
+                             </property>
+                             <property name="singleStep">
+                              <number>1</number>
+                             </property>
+                             <property name="value">
+                              <number>100</number>
+                             </property>
+                            </widget>
+                           </item>
+                           <item row="14" column="1">
+                            <widget class="QLabel" name="label_auto_raman_max_avg">
+                             <property name="sizePolicy">
+                              <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                               <horstretch>0</horstretch>
+                               <verstretch>0</verstretch>
+                              </sizepolicy>
+                             </property>
+                             <property name="layoutDirection">
+                              <enum>Qt::LayoutDirection::RightToLeft</enum>
+                             </property>
+                             <property name="text">
+                              <string>Max Averaging</string>
+                             </property>
+                            </widget>
+                           </item>
                            
-                           <item row="14" column="0" colspan="2">
+                           <item row="15" column="0" colspan="2">
                             <widget class="QCheckBox" name="checkBox_auto_raman_retain_settings">
                              <property name="sizePolicy">
                               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -16556,6 +16627,20 @@ li.checked::marker { content: "\2612"; }
                              </property>
                              <property name="text">
                               <string>Retain Auto-Raman Settings</string>
+                             </property>
+                            </widget>
+                           </item>
+
+                           <item row="16" column="0" colspan="2">
+                            <widget class="QCheckBox" name="checkBox_auto_raman_auto_save">
+                             <property name="sizePolicy">
+                              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                               <horstretch>0</horstretch>
+                               <verstretch>0</verstretch>
+                              </sizepolicy>
+                             </property>
+                             <property name="text">
+                              <string>Automatically Save</string>
                              </property>
                             </widget>
                            </item>

--- a/enlighten/common.py
+++ b/enlighten/common.py
@@ -13,7 +13,7 @@ application.
       can be modules (files) within it
 """
 
-VERSION = "4.1.8"
+VERSION = "4.1.9"
 
 ctl = None
 

--- a/enlighten/common.py
+++ b/enlighten/common.py
@@ -13,7 +13,7 @@ application.
       can be modules (files) within it
 """
 
-VERSION = "4.1.9"
+VERSION = "4.1.10"
 
 ctl = None
 

--- a/enlighten/common.py
+++ b/enlighten/common.py
@@ -13,7 +13,7 @@ application.
       can be modules (files) within it
 """
 
-VERSION = "4.1.10"
+VERSION = "4.1.11"
 
 ctl = None
 

--- a/enlighten/common.py
+++ b/enlighten/common.py
@@ -13,7 +13,7 @@ application.
       can be modules (files) within it
 """
 
-VERSION = "4.1.7"
+VERSION = "4.1.8"
 
 ctl = None
 

--- a/enlighten/device/EEPROMEditor.py
+++ b/enlighten/device/EEPROMEditor.py
@@ -147,6 +147,7 @@ class EEPROMEditor:
         self.bind_checkBox        (cfu.checkBox_ee_has_shutter,               "has_shutter")
         self.bind_checkBox        (cfu.checkBox_ee_disable_ble_power,         "disable_ble_power")
         self.bind_checkBox        (cfu.checkBox_ee_disable_laser_armed_indicator, "disable_laser_armed_indicator")
+        self.bind_checkBox        (cfu.checkBox_ee_ssc_enabled,               "ssc_enabled")
 
         # To be clear: we're editing the float version of excitation_nm. Edits 
         # are automatically rounded and re-saved to the integral version. We 
@@ -505,12 +506,17 @@ class EEPROMEditor:
             elif name == "subformat":
                 self.update_subformat()
 
+            # vertical ROI
             elif "roi_vertical_region_1" in name:
                 spec = self.ctl.multispec.current_spectrometer()
                 if spec is not None:
                     end = self.eeprom.roi_vertical_region_1_end
                     start = self.eeprom.roi_vertical_region_1_start
                     spec.change_device_setting("vertical_binning", (start, end))
+
+            # SSC
+            elif "ssc_enabled" in name:
+                spec.change_device_setting("ssc_enabled", value)
 
             # send "user" updates downstream (not when switching between spectrometers though)
             if self.updated_from_eeprom:
@@ -527,9 +533,6 @@ class EEPROMEditor:
 
         # TODO: call Controller.change_setting("eeprom", self.eeprom) on 
         #       successful value change?
-        #
-        # Before we do that, we better be DAMN sure we're sending to the right
-        # serial number (maybe send a (serial_number, eeprom) tuple).
 
     # ##########################################################################
     # methods

--- a/enlighten/device/GainDBFeature.py
+++ b/enlighten/device/GainDBFeature.py
@@ -25,12 +25,6 @@ class GainDBFeature:
     persisted through EEPROM anymore than is, say, momentary integration time
     used to update startupIntegrationTimeMS.
     
-    Note that although the SiG can actually handle gain in increments of 0.1dB,
-    and our FunkyFloat type can support increments of 1/256 dB, the widget is
-    currently implemented as an integral QSpinBox (not QDoubleSpinBox), so
-    UI precision is currently 1dB.
-    
-    @todo support UI gain resolution of 0.1 dB
     @see additional notes in wasatch.SpectrometerState
     """
 
@@ -42,20 +36,23 @@ class GainDBFeature:
         self.ctl = ctl
         cfu = ctl.form.ui
 
+        self.spinbox = cfu.doubleSpinBox_gain 
+
         self.widgets = [
             cfu.pushButton_gain_dn,
             cfu.pushButton_gain_up,
             cfu.label_gainWidget_title,
             cfu.slider_gain,
-            cfu.doubleSpinBox_gain ]
+            self.spinbox ]
 
         self.locked = False # when Locked, don't show on-screen even in Expert mode
+        self.visible = False
 
         # bindings
+        self.spinbox.valueChanged.connect(self._sync_spinbox_to_slider_callback)
+        self.spinbox.installEventFilter(ScrollStealFilter(self.spinbox))
         cfu.slider_gain.valueChanged.connect(self._sync_slider_to_spinbox_callback)
         cfu.slider_gain.installEventFilter(MouseWheelFilter(cfu.slider_gain))
-        cfu.doubleSpinBox_gain.valueChanged.connect(self._sync_spinbox_to_slider_callback)
-        cfu.doubleSpinBox_gain.installEventFilter(ScrollStealFilter(cfu.doubleSpinBox_gain))
         cfu.pushButton_gain_up.clicked.connect(self._up_callback)
         cfu.pushButton_gain_dn.clicked.connect(self._dn_callback)
 
@@ -77,21 +74,21 @@ class GainDBFeature:
         """
 
         if self.locked:
-            visible = False
+            self.visible = False
         else:
             spec = self.ctl.multispec.current_spectrometer()
             if spec is None:
-                visible = False
+                self.visible = False
             else:
-                visible = spec.settings.is_micro() and self.ctl.page_nav.doing_expert()
+                self.visible = spec.settings.is_micro() and self.ctl.page_nav.doing_expert()
 
         # normally we'd do this at the enclosing frame, but gain is currently 
         # nested within the detectorControlWidget, and a sub-frame breaks the
         # CSS, so...just disappear the widgets for now
         for w in self.widgets:
-            w.setVisible(visible)
+            w.setVisible(self.visible)
 
-        return visible
+        return self.visible
 
     def init_hotplug(self):
         """ called by initialize_new_device on hotplug, BEFORE reading / applying .ini """
@@ -121,10 +118,10 @@ class GainDBFeature:
             self.set_db(db)
 
             # apply limits to SPINBOX
-            self.ctl.form.ui.doubleSpinBox_gain.blockSignals(True)
-            self.ctl.form.ui.doubleSpinBox_gain.setMinimum(self.MIN_GAIN_DB)
-            self.ctl.form.ui.doubleSpinBox_gain.setMaximum(self.MAX_GAIN_DB)
-            self.ctl.form.ui.doubleSpinBox_gain.blockSignals(False)
+            self.spinbox.blockSignals(True)
+            self.spinbox.setMinimum(self.MIN_GAIN_DB)
+            self.spinbox.setMaximum(self.MAX_GAIN_DB)
+            self.spinbox.blockSignals(False)
 
     def _quiet_set(self, widget, value):
         """ Set the value of a widget without invoking the ValueChanged event """
@@ -133,8 +130,9 @@ class GainDBFeature:
         widget.blockSignals(False)
 
     def set_focus(self):
-        self.spinbox.setFocus()
-        self.spinbox.selectAll()
+        if self.visible:
+            self.spinbox.setFocus()
+            self.spinbox.selectAll()
 
     def set_db(self, db, quiet=False):
         spec = self.ctl.multispec.current_spectrometer()
@@ -156,28 +154,28 @@ class GainDBFeature:
         self.ctl.multispec.change_device_setting("detector_gain", db)
 
         # ensure both gain widgets are correct, without generating additional events
-        self._quiet_set(self.ctl.form.ui.doubleSpinBox_gain, db)
+        self._quiet_set(self.spinbox, db)
         self._quiet_set(self.ctl.form.ui.slider_gain, db)
 
         if not quiet:
             spec.app_state.check_refs()
 
     def _up_callback(self):
-        util.incr_spinbox(self.ctl.form.ui.doubleSpinBox_gain)
-        self.set_db(self.ctl.form.ui.doubleSpinBox_gain.value())
+        util.incr_spinbox(self.spinbox)
+        self.set_db(self.spinbox.value())
 
     def _dn_callback(self):
-        util.decr_spinbox(self.ctl.form.ui.doubleSpinBox_gain)
-        self.set_db(self.ctl.form.ui.doubleSpinBox_gain.value())
+        util.decr_spinbox(self.spinbox)
+        self.set_db(self.spinbox.value())
 
     def _sync_slider_to_spinbox_callback(self):
         self.set_db(self.ctl.form.ui.slider_gain.value()) 
 
     def _sync_spinbox_to_slider_callback(self):
-        self.set_db(self.ctl.form.ui.doubleSpinBox_gain.value())
+        self.set_db(self.spinbox.value())
 
     def get_db(self):
-        return self.ctl.form.ui.doubleSpinBox_gain.value()
+        return self.spinbox.value()
 
     def set_db_callback(self, value):
         """ used by Presets """

--- a/enlighten/measurement/Measurement.py
+++ b/enlighten/measurement/Measurement.py
@@ -222,8 +222,8 @@ class Measurement:
                            'Baseline Correction Algo',
                            'ROI Pixel Start',
                            'ROI Pixel End',
-                           'ROI Vertical Pixel Start',
-                           'ROI Vertical Pixel End',
+                           'ROI Start Line',
+                           'ROI Stop Line',
                            'CCD C4',
                            'Slit Width',
                            'Cropped',
@@ -862,8 +862,8 @@ class Measurement:
         if field == "declared score":            return self.declared_match.score if self.declared_match is not None else 0
         if field == "roi pixel start":           return self.settings.eeprom.roi_horizontal_start
         if field == "roi pixel end":             return self.settings.eeprom.roi_horizontal_end
-        if field == "roi vertical pixel start":  return self.settings.eeprom.roi_vertical_region_1_start
-        if field == "roi vertical pixel end":    return self.settings.eeprom.roi_vertical_region_1_end
+        if field == "roi start line":            return self.settings.eeprom.roi_vertical_region_1_start
+        if field == "roi stop line":             return self.settings.eeprom.roi_vertical_region_1_end
         if field == "cropped":                   return self.processed_reading.is_cropped()
         if field == "interpolated":              return self.ctl.interp.enabled if self.ctl else False
         if field == "raman intensity corrected": return self.processed_reading.raman_intensity_corrected

--- a/enlighten/post_processing/AutoRamanFeature.py
+++ b/enlighten/post_processing/AutoRamanFeature.py
@@ -25,21 +25,19 @@ class AutoRamanFeature:
         self.ctl = ctl
         cfu = self.ctl.form.ui
 
-        self.bt_laser       = cfu.pushButton_laser_toggle
-        self.bt_measure     = cfu.pushButton_auto_raman_measurement
-        self.bt_convenience = cfu.pushButton_auto_raman_convenience
-        self.cb_config      = cfu.checkBox_auto_raman_config
-        self.cb_retain      = cfu.checkBox_auto_raman_retain_settings
-        self.fr_config      = cfu.frame_auto_raman_config
-        self.buttons        = [ self.bt_measure, self.bt_convenience ]
+        self.bt_laser           = cfu.pushButton_laser_toggle
+        self.bt_measure         = cfu.pushButton_auto_raman_measurement
+        self.bt_convenience     = cfu.pushButton_auto_raman_convenience
+        self.cb_config          = cfu.checkBox_auto_raman_config
+        self.cb_retain_settings = cfu.checkBox_auto_raman_retain_settings
+        self.cb_auto_save       = cfu.checkBox_auto_raman_auto_save
+        self.fr_config          = cfu.frame_auto_raman_config
+        self.buttons            = [ self.bt_measure, self.bt_convenience ]
 
         self.visible = False
         self.running = False
+        self.auto_save = False
         self.retain_settings = False
-
-        for b in self.buttons:
-            b.clicked.connect(self.measure_callback)
-        self.cb_config.stateChanged.connect(self.update_visibility)
 
         self.sb_max_ms                  = cfu.spinBox_auto_raman_max_ms           
         self.sb_start_integ_ms          = cfu.spinBox_auto_raman_start_integ_ms   
@@ -52,24 +50,17 @@ class AutoRamanFeature:
         self.sb_max_counts              = cfu.spinBox_auto_raman_max_counts       
         self.sb_min_counts              = cfu.spinBox_auto_raman_min_counts       
         self.sb_max_factor              = cfu.spinBox_auto_raman_max_factor       
+        self.sb_max_avg                 = cfu.spinBox_auto_raman_max_avg
         self.sb_saturation              = cfu.spinBox_auto_raman_saturation       
         self.ds_drop_factor             = cfu.doubleSpinBox_auto_raman_drop_factor
         self.sb_laser_warning_delay_sec = cfu.spinBox_auto_raman_laser_warning_delay_sec
 
-        self.sb_max_ms                 .valueChanged.connect(self.update_from_gui)
-        self.sb_start_integ_ms         .valueChanged.connect(self.update_from_gui)
-        self.sb_start_gain_db          .valueChanged.connect(self.update_from_gui)
-        self.sb_max_integ_ms           .valueChanged.connect(self.update_from_gui)
-        self.sb_min_integ_ms           .valueChanged.connect(self.update_from_gui)
-        self.sb_max_gain_db            .valueChanged.connect(self.update_from_gui)
-        self.sb_min_gain_db            .valueChanged.connect(self.update_from_gui)
-        self.sb_target_counts          .valueChanged.connect(self.update_from_gui)
-        self.sb_max_counts             .valueChanged.connect(self.update_from_gui)
-        self.sb_min_counts             .valueChanged.connect(self.update_from_gui)
-        self.sb_max_factor             .valueChanged.connect(self.update_from_gui)
-        self.sb_saturation             .valueChanged.connect(self.update_from_gui)
-        self.ds_drop_factor            .valueChanged.connect(self.update_from_gui)
-        self.sb_laser_warning_delay_sec.valueChanged.connect(self.update_from_gui)
+        self.cb_config          .clicked    .connect(self.update_config)
+        self.cb_retain_settings .clicked    .connect(self.update_config)
+        self.cb_auto_save       .clicked    .connect(self.update_config)
+        for b in self.buttons:
+            b.clicked.connect(self.measure_callback)
+
 
         for widget in [ self.sb_max_ms,
                         self.sb_start_integ_ms,
@@ -82,6 +73,7 @@ class AutoRamanFeature:
                         self.sb_max_counts,
                         self.sb_min_counts,
                         self.sb_max_factor,
+                        self.sb_max_avg,
                         self.sb_saturation,
                         self.ds_drop_factor,
                         self.sb_laser_warning_delay_sec ]:
@@ -98,9 +90,12 @@ class AutoRamanFeature:
         ctl.presets.register(self, "auto_raman_max_counts"             , setter=self.set_max_counts             , getter=self.get_max_counts             )
         ctl.presets.register(self, "auto_raman_min_counts"             , setter=self.set_min_counts             , getter=self.get_min_counts             )
         ctl.presets.register(self, "auto_raman_max_factor"             , setter=self.set_max_factor             , getter=self.get_max_factor             )
+        ctl.presets.register(self, "auto_raman_max_avg"                , setter=self.set_max_avg                , getter=self.get_max_avg                )
         ctl.presets.register(self, "auto_raman_saturation"             , setter=self.set_saturation             , getter=self.get_saturation             )
         ctl.presets.register(self, "auto_raman_drop_factor"            , setter=self.set_drop_factor            , getter=self.get_drop_factor            )
         ctl.presets.register(self, "auto_raman_laser_warning_delay_sec", setter=self.set_laser_warning_delay_sec, getter=self.get_laser_warning_delay_sec)
+
+        self.init_from_config()
 
         for b in self.buttons:
             b.setWhatsThis(unwrap("""
@@ -130,6 +125,20 @@ class AutoRamanFeature:
 
         self.update_visibility()
 
+    def init_from_config(self):
+        s = "Auto-Raman"
+        self.cb_config         .setChecked(self.ctl.config.get_bool(s, "config"))
+        self.cb_auto_save      .setChecked(self.ctl.config.get_bool(s, "auto_save"))
+        self.cb_retain_settings.setChecked(self.ctl.config.get_bool(s, "retain_settings"))
+
+    def update_config(self):
+        self.update_visibility()
+
+        s = "Auto-Raman"
+        self.ctl.config.set(s, "config",          self.cb_config.isChecked())
+        self.ctl.config.set(s, "auto_save",       self.auto_save)
+        self.ctl.config.set(s, "retain_settings", self.retain_settings)
+
     ##
     # called by Controller.disconnect_device to ensure we turn this off between
     # connections
@@ -144,7 +153,8 @@ class AutoRamanFeature:
             self.visible = self.ctl.page_nav.doing_raman() and \
                            spec.settings.eeprom.has_laser
 
-        self.retain_settings = self.visible and self.cb_retain.isChecked()
+        self.auto_save = self.cb_retain_settings.isChecked()
+        self.retain_settings = self.cb_retain_settings.isChecked()
 
         for b in self.buttons:
             b.setVisible(self.visible)
@@ -157,7 +167,6 @@ class AutoRamanFeature:
             self.fr_config.setVisible(False)
 
     def measure_callback(self):
-        log.debug(f"measure_callback: starting")
 
         # ensure we're paused
         self.ctl.vcr_controls.pause()
@@ -189,25 +198,22 @@ class AutoRamanFeature:
             max_counts              = self.get_max_counts    (),
             min_counts              = self.get_min_counts    (),
             max_factor              = self.get_max_factor    (),
+            max_avg                 = self.get_max_avg       (),
             saturation              = self.get_saturation    (),
             drop_factor             = self.get_drop_factor   (),
             laser_warning_delay_sec = self.get_laser_warning_delay_sec())
+
         take_one_request = TakeOneRequest(auto_raman_request=auto_raman_request)
 
-        log.debug(f"measure_callback: starting TakeOne")
-        self.ctl.take_one.start(completion_callback=self.completion_callback, stop_callback=self.stop_callback, template=take_one_request)
-
-        log.debug(f"measure_callback: done")
+        self.ctl.take_one.start(completion_callback=self.completion_callback, stop_callback=self.stop_callback, template=take_one_request, save=self.auto_save)
 
     def stop_callback(self):
-        log.debug(f"stop_callback: here")
         self.running = False
         for b in self.buttons:
             self.ctl.gui.colorize_button(b, False)
         self.ctl.marquee.error("Auto-Raman measurement cancelled")
 
     def completion_callback(self):
-        log.debug(f"completion_callback: here")
         # self.ctl.laser_control.refresh_laser_buttons()
         self.running = False
         for b in self.buttons:
@@ -217,22 +223,18 @@ class AutoRamanFeature:
     def process_reading(self, reading):
         spec = self.ctl.multispec.current_spectrometer()
         if spec.device_id != reading.device_id:
-            log.debug("process_reading: ignoring non-selected spectrometer reading")
             return
 
+        log.debug("processing reading")
+
         if self.retain_settings:
-            log.debug("retaining Auto-Raman settings")
             if reading.dark is not None:
-                log.debug("retaining Auto-Raman dark")
                 self.ctl.dark_feature.store(reading.dark)
             if reading.new_integration_time_ms is not None:
-                log.debug("retaining Auto-Raman integ")
                 self.ctl.integration_time_feature.set_ms(reading.new_integration_time_ms, quiet=True)
             if reading.new_gain_db is not None:
-                log.debug("retaining Auto-Raman gain")
                 self.ctl.gain_db_feature.set_db(reading.new_gain_db, quiet=True)
             if reading.sum_count is not None:
-                log.debug("retaining Auto-Raman avg")
                 self.ctl.scan_averaging.set_scans_to_average(max(1, reading.sum_count))
         else:
             # we aren't retaining the Auto-Dark settings in the GUI, so you'd 
@@ -240,23 +242,11 @@ class AutoRamanFeature:
             # set the settings in the spectrometer itself, which at this point 
             # (under the current wasatch.AutoRaman design) are still free-running
             # at whatever optimized values the AutoRaman algo computed
-
-            log.debug("NOT retaining Auto-Raman settings")
-            if reading.dark is not None:
-                log.debug("NOT retaining Auto-Raman dark")
             if reading.new_integration_time_ms is not None:
-                log.debug("NOT retaining Auto-Raman integ (re-setting)")
                 self.ctl.integration_time_feature.set_ms(spec.settings.state.integration_time_ms, quiet=True)
             if reading.new_gain_db is not None:
-                log.debug("NOT retaining Auto-Raman gain (re-setting)")
                 self.ctl.gain_db_feature.set_db(spec.settings.state.gain_db, quiet=True)
-            if reading.sum_count is not None:
-                log.debug("NOT retaining Auto-Raman avg")
             
-
-    def update_from_gui(self):
-        pass
-
     def set_max_ms                 (self, value): self.sb_max_ms                 .setValue(int(value))
     def set_start_integ_ms         (self, value): self.sb_start_integ_ms         .setValue(int(value))
     def set_start_gain_db          (self, value): self.sb_start_gain_db          .setValue(int(value))
@@ -268,6 +258,7 @@ class AutoRamanFeature:
     def set_max_counts             (self, value): self.sb_max_counts             .setValue(int(value))
     def set_min_counts             (self, value): self.sb_min_counts             .setValue(int(value))
     def set_max_factor             (self, value): self.sb_max_factor             .setValue(int(value))
+    def set_max_avg                (self, value): self.sb_max_avg                .setValue(int(value))
     def set_saturation             (self, value): self.sb_saturation             .setValue(int(value))
     def set_drop_factor            (self, value): self.ds_drop_factor            .setValue(float(value))
     def set_laser_warning_delay_sec(self, value): self.sb_laser_warning_delay_sec.setValue(int(value))
@@ -283,6 +274,7 @@ class AutoRamanFeature:
     def get_max_counts             (self): return self.sb_max_counts             .value()
     def get_min_counts             (self): return self.sb_min_counts             .value()
     def get_max_factor             (self): return self.sb_max_factor             .value()
+    def get_max_avg                (self): return self.sb_max_avg                .value()
     def get_saturation             (self): return self.sb_saturation             .value()
     def get_drop_factor            (self): return self.ds_drop_factor            .value()
     def get_laser_warning_delay_sec(self): return self.sb_laser_warning_delay_sec.value()

--- a/enlighten/ui/HelpFeature.py
+++ b/enlighten/ui/HelpFeature.py
@@ -57,6 +57,8 @@ class HelpFeature:
             Ctrl-S Save measurement
             Ctrl-T enter integration Time
             Ctrl-X toggle eXpert mode
+
+            Ctrl-* Auto-Raman
             
             Ctrl-Left  move cursor
             Ctrl-Right move cursor"""))


### PR DESCRIPTION
- AutoRaman
    - add "auto-save" checkbox (persisted)
    - add "Retain Auto-Raman Settings" checkbox (persisted)
    - add scan averaging to retained Auto-Raman settings
    - if not retaining, still use (but don't store) averaged dark
    - expose maxScansToAverage AutoRamanRequest option
    - add Ctrl-* shortcut
- 2x2 binning
    - add "SSC Enabled" checkbox to test alternate IMX385 binning factors
    - save Auto-Raman parameters in Measurement / CSV files, whether retained or not

Related to https://github.com/WasatchPhotonics/Wasatch.PY/pull/111